### PR TITLE
Fix for MongoDB ratio reporting bug

### DIFF
--- a/mongodb/conf.d/mongodb.conf
+++ b/mongodb/conf.d/mongodb.conf
@@ -60,7 +60,7 @@ collection_group {
         title = "Global Write Lock Ratio"
     }
     metric {
-        name = "mongodb_indexCounters_btree_misses"
+        name = "mongodb_indexCounters_btree_miss_ratio"
         title = "BTree Page Miss Ratio"
     }
     metric {

--- a/mongodb/python_modules/mongodb.py
+++ b/mongodb/python_modules/mongodb.py
@@ -107,7 +107,7 @@ def get_globalLock_ratio(name):
     return result
 
 
-def indexCounters_btree_missRatio(name):
+def indexCounters_btree_miss_ratio(name):
     """Return the btree miss ratio"""
 
     try:
@@ -264,8 +264,8 @@ def metric_init(lparams):
             'groups': groups
         },
         {
-            'name': NAME_PREFIX + 'indexCounters_btree_missRatio',
-            'call_back': indexCounters_btree_missRatio,
+            'name': NAME_PREFIX + 'indexCounters_btree_miss_ratio',
+            'call_back': indexCounters_btree_miss_ratio,
             'time_max': time_max,
             'value_type': 'float',
             'units': '%',


### PR DESCRIPTION
Hey guys,

I just fixed a bug in the way MongoDB's global lock and btree miss ratios were being reported. I also made some trivial changes to the other two modules I submitted a while back.
