### PR TITLE
gmetric compatibility fixes

### DIFF
--- a/diskstat/python_modules/diskstat.py
+++ b/diskstat/python_modules/diskstat.py
@@ -41,6 +41,8 @@ import subprocess
 import traceback
 import logging
 
+descriptors = []
+
 logging.basicConfig(level=logging.ERROR, format="%(asctime)s - %(name)s - %(levelname)s\t Thread-%(thread)d - %(message)s", filename='/tmp/gmond.log', filemode='w')
 logging.debug('starting up')
 
@@ -280,7 +282,6 @@ def metric_init(params):
 
 	update_stats()
 
-	descriptors = []
 	for label in descriptions:
 		for dev in PARTITIONS: 
 			if stats[dev].has_key(label):

--- a/ehcache/python_modules/ehcache.py
+++ b/ehcache/python_modules/ehcache.py
@@ -20,6 +20,8 @@ import traceback, sys, re
 import tempfile
 import logging
 
+descriptors = []
+
 logging.basicConfig(level=logging.ERROR, format="%(asctime)s - %(name)s - %(levelname)s\t Thread-%(thread)d - %(message)s", filename='/tmp/gmond.log', filemode='w')
 #logging.basicConfig(level=logging.DEBUG, format="%(asctime)s - %(name)s - %(levelname)s\t Thread-%(thread)d - %(message)s", filename='/tmp/gmond.log2')
 logging.debug('starting up')
@@ -147,7 +149,6 @@ def metric_init(params):
 		descriptions[name] = {}
 
 	time_max = 60
-	descriptors = []
 	for label in descriptions:
 		if stats.has_key(label):
 

--- a/httpd/python_modules/httpd.py
+++ b/httpd/python_modules/httpd.py
@@ -42,6 +42,8 @@ import traceback
 import sys, re
 import logging
 
+descriptors = []
+
 logging.basicConfig(level=logging.ERROR, format="%(asctime)s - %(name)s - %(levelname)s\t Thread-%(thread)d - %(message)s", filename='/tmp/gmond.log', filemode='w')
 logging.debug('starting up')
 
@@ -361,7 +363,6 @@ def metric_init(params):
 	update_stats()
 	update_server_stats()
 
-	descriptors = []
 	for label in descriptions:
 		if httpd_stats.has_key(label):
 			d = {

--- a/jmxsh/python_modules/jmxsh.py
+++ b/jmxsh/python_modules/jmxsh.py
@@ -38,6 +38,8 @@ import traceback, sys, re
 import tempfile
 import logging
 
+descriptors = []
+
 logging.basicConfig(level=logging.ERROR, format="%(asctime)s - %(name)s - %(levelname)s\t Thread-%(thread)d - %(message)s", filename='/tmp/gmond.log', filemode='w')
 #logging.basicConfig(level=logging.DEBUG, format="%(asctime)s - %(name)s - %(levelname)s\t Thread-%(thread)d - %(message)s", filename='/tmp/gmond.log2')
 logging.debug('starting up')
@@ -240,7 +242,6 @@ def metric_init(params):
 		}
 
 	time_max = 60
-	descriptors = []
 	for label in descriptions:
 		if stats.has_key(label):
 

--- a/mysqld/python_modules/mysql.py
+++ b/mysqld/python_modules/mysql.py
@@ -45,6 +45,9 @@ import MySQLdb
 from DBUtil import parse_innodb_status
 
 import logging
+
+descriptors = []
+
 logging.basicConfig(level=logging.ERROR, format="%(asctime)s - %(name)s - %(levelname)s\t Thread-%(thread)d - %(message)s", filename='/tmp/gmond.log', filemode='w')
 logging.debug('starting up')
 
@@ -990,7 +993,6 @@ def metric_init(params):
 			},
 		)
 
-	descriptors = []
 	update_stats(REPORT_INNODB, REPORT_MASTER, REPORT_SLAVE)
 
 	time.sleep(MAX_UPDATE_TIME)

--- a/procstat/python_modules/procstat.py
+++ b/procstat/python_modules/procstat.py
@@ -105,6 +105,8 @@ import os.path
 import glob
 import logging
 
+descriptors = []
+
 logging.basicConfig(level=logging.ERROR, format="%(asctime)s - %(name)s - %(levelname)s\t Thread-%(thread)d - %(message)s", filename='/tmp/gmond.log', filemode='w')
 logging.debug('starting up')
 
@@ -372,7 +374,6 @@ def metric_init(params):
 	)
 
 	time_max = 60
-	descriptors = []
 	for label in descriptions:
 		for proc in PROCESSES:
 			if stats[proc].has_key(label):


### PR DESCRIPTION
originally found while trying to run the procstat module standalone, generating gmetric calls through the '-g' option, hence this pull request still includes a procstat specific spell checking fix that was added then.

all modules share the same bug and are therefore better corrected together
