### PR TITLE
Fix to an error on varnish plugin

### DIFF
--- a/varnish/python_modules/varnish.py
+++ b/varnish/python_modules/varnish.py
@@ -61,7 +61,10 @@ def get_metrics():
         metrics = {}
         for line in io.readlines():
             values = line.split()[:2]
-            metrics[values[0]] = int(values[1])
+            try:
+                metrics[values[0]] = int(values[1])
+            except ValueError:
+                metrics[values[0]] = 0
 
         # update cache
         LAST_METRICS = dict(METRICS)
@@ -139,7 +142,7 @@ def metric_init(lparams):
         'description' : 'XXX',
         'groups'      : 'varnish',
         }
-    
+
     descriptors = []
 
     descriptors.append( create_desc(Desc_Skel, {
@@ -155,672 +158,672 @@ def metric_init(lparams):
                 "units"      : "conn/s",
                 "description": "Client connections accepted",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'client_drop',
                 "call_back"  : get_delta,
                 "units"      : "conn/s",
                 "description": "Connection dropped, no sess/wrk",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'client_req',
                 "call_back"  : get_delta,
                 "units"      : "req/s",
                 "description": "Client requests received",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'cache_hit',
                 "call_back"  : get_delta,
                 "units"      : "hit/s",
                 "description": "Cache hits",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'cache_hitpass',
                 "call_back"  : get_delta,
                 "units"      : "hit/s",
                 "description": "Cache hits for pass",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'cache_miss',
                 "units"      : "miss/s",
                 "call_back"  : get_delta,
                 "description": "Cache misses",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'backend_conn',
                 "call_back"  : get_delta,
                 "units"      : "conn/s",
                 "description": "Backend conn. success",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'backend_unhealthy',
                 "call_back"  : get_delta,
                 "units"      : "conn/s",
                 "description": "Backend conn. not attempted",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'backend_busy',
                 "call_back"  : get_delta,
                 "units"      : "busy/s",
                 "description": "Backend conn. too many",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'backend_fail',
                 "call_back"  : get_delta,
                 "units"      : "fail/s",
                 "description": "Backend conn. failures",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'backend_reuse',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "Backend conn. reuses",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'backend_toolate',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "Backend conn. was closed",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'backend_recycle',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "Backend conn. recycles",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'backend_unused',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "Backend conn. unused",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'fetch_head',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "Fetch head",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'fetch_length',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "Fetch with Length",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'fetch_chunked',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "Fetch chunked",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'fetch_eof',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "Fetch EOF",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'fetch_bad',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "Fetch had bad headers",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'fetch_close',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "Fetch wanted close",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'fetch_oldhttp',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "Fetch pre HTTP/1.1 closed",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'fetch_zero',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "Fetch zero len",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'fetch_failed',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "Fetch failed",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_sess_mem',
                 "call_back"  : get_value,
                 "units"      : "Bytes",
                 "description": "N struct sess_mem",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_sess',
                 "call_back"  : get_value,
                 "units"      : "sessions",
                 "description": "N struct sess",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_object',
                 "call_back"  : get_value,
                 "units"      : "objects",
                 "description": "N struct object",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_vampireobject',
                 "call_back"  : get_value,
                 "units"      : "objects",
                 "description": "N unresurrected objects",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_objectcore',
                 "call_back"  : get_value,
                 "units"      : "objects",
                 "description": "N struct objectcore",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_objecthead',
                 "call_back"  : get_value,
                 "units"      : "objects",
                 "description": "N struct objecthead",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_smf',
                 "call_back"  : get_value,
                 "units"      : "",
                 "description": "N struct smf",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_smf_frag',
                 "call_back"  : get_value,
                 "units"      : "frags",
                 "description": "N small free smf",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_smf_large',
                 "call_back"  : get_value,
                 "units"      : "frags",
                 "description": "N large free smf",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_vbe_conn',
                 "call_back"  : get_value,
                 "units"      : "conn",
                 "description": "N struct vbe_conn",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_wrk',
                 "call_back"  : get_value,
                 "units"      : "threads",
                 "description": "N worker threads",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_wrk_create',
                 "call_back"  : get_delta,
                 "units"      : "threads/s",
                 "description": "N worker threads created",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_wrk_failed',
                 "call_back"  : get_delta,
                 "units"      : "wrk/s",
                 "description": "N worker threads not created",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_wrk_max',
                 "call_back"  : get_delta,
                 "units"      : "threads/s",
                 "description": "N worker threads limited",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_wrk_queue',
                 "call_back"  : get_value,
                 "units"      : "req",
                 "description": "N queued work requests",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_wrk_overflow',
                 "call_back"  : get_delta,
                 "units"      : "req/s",
                 "description": "N overflowed work requests",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_wrk_drop',
                 "call_back"  : get_delta,
                 "units"      : "req/s",
                 "description": "N dropped work requests",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_backend',
                 "call_back"  : get_value,
                 "units"      : "backends",
                 "description": "N backends",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_expired',
                 "call_back"  : get_delta,
                 "units"      : "obj/s",
                 "description": "N expired objects",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_lru_nuked',
                 "call_back"  : get_delta,
                 "units"      : "obj/s",
                 "description": "N LRU nuked objects",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_lru_saved',
                 "call_back"  : get_delta,
                 "units"      : "obj/s",
                 "description": "N LRU saved objects",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_lru_moved',
                 "call_back"  : get_delta,
                 "units"      : "obj/s",
                 "description": "N LRU moved objects",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_deathrow',
                 "call_back"  : get_delta,
                 "units"      : "obj/s",
                 "description": "N objects on deathrow",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'losthdr',
                 "call_back"  : get_delta,
                 "units"      : "hdrs/s",
                 "description": "HTTP header overflows",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_objsendfile',
                 "call_back"  : get_delta,
                 "units"      : "obj/s",
                 "description": "Objects sent with sendfile",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_objwrite',
                 "call_back"  : get_delta,
                 "units"      : "obj/s",
                 "description": "Objects sent with write",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_objoverflow',
                 "call_back"  : get_delta,
                 "description": "Objects overflowing workspace",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 's_sess',
                 "call_back"  : get_delta,
                 "description": "Total Sessions",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 's_req',
                 "call_back"  : get_delta,
                 "description": "Total Requests",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 's_pipe',
                 "call_back"  : get_delta,
                 "description": "Total pipe",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 's_pass',
                 "call_back"  : get_delta,
                 "description": "Total pass",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 's_fetch',
                 "call_back"  : get_delta,
                 "description": "Total fetch",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 's_hdrbytes',
                 "call_back"  : get_delta,
                 "description": "Total header bytes",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 's_bodybytes',
                 "call_back"  : get_delta,
                 "units"      : "bytes/s",
                 "description": "Total body bytes",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'sess_closed',
                 "call_back"  : get_delta,
                 "units"      : "sessions/s",
                 "description": "Session Closed",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'sess_pipeline',
                 "call_back"  : get_delta,
                 "description": "Session Pipeline",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'sess_readahead',
                 "call_back"  : get_delta,
                 "description": "Session Read Ahead",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'sess_linger',
                 "call_back"  : get_delta,
                 "description": "Session Linger",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'sess_herd',
                 "call_back"  : get_delta,
                 "description": "Session herd",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'shm_records',
                 "call_back"  : get_delta,
                 "description": "SHM records",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'shm_writes',
                 "call_back"  : get_delta,
                 "description": "SHM writes",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'shm_flushes',
                 "call_back"  : get_delta,
                 "description": "SHM flushes due to overflow",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'shm_cont',
                 "call_back"  : get_delta,
                 "description": "SHM MTX contention",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'shm_cycles',
                 "call_back"  : get_delta,
                 "description": "SHM cycles through buffer",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'sm_nreq',
                 "call_back"  : get_delta,
                 "description": "allocator requests",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'sm_nobj',
                 "call_back"  : get_delta,
                 "description": "outstanding allocations",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'sm_balloc',
                 "call_back"  : get_value,
                 "description": "bytes allocated",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'sm_bfree',
                 "call_back"  : get_delta,
                 "description": "bytes free",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'sma_nreq',
                 "call_back"  : get_delta,
                 "description": "SMA allocator requests",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'sma_nobj',
                 "call_back"  : get_value,
                 "units"      : "obj",
                 "description": "SMA outstanding allocations",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'sma_nbytes',
                 "call_back"  : get_value,
                 "units"      : "Bytes",
                 "description": "SMA outstanding bytes",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'sma_balloc',
                 "call_back"  : get_delta,
                 "units"      : "bytes/s",
                 "description": "SMA bytes allocated",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'sma_bfree',
                 "call_back"  : get_delta,
                 "units"      : "bytes/s",
                 "description": "SMA bytes free",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'sms_nreq',
                 "call_back"  : get_delta,
                 "units"      : "req/s",
                 "description": "SMS allocator requests",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'sms_nobj',
                 "call_back"  : get_value,
-                "units"      : "obj",                
+                "units"      : "obj",
                 "description": "SMS outstanding allocations",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'sms_nbytes',
                 "call_back"  : get_value,
                 "units"      : "Bytes",
                 "description": "SMS outstanding bytes",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'sms_balloc',
                 "call_back"  : get_delta,
                 "units"      : "bytes/s",
                 "description": "SMS bytes allocated",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'sms_bfree',
                 "call_back"  : get_delta,
                 "units"      : "Bytes/s",
                 "description": "SMS bytes freed",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'backend_req',
                 "call_back"  : get_delta,
                 "units"      : "req/s",
                 "description": "Backend requests made",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_vcl',
                 "call_back"  : get_value,
                 "units"      : "vcl",
                 "description": "N vcl total",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_vcl_avail',
                 "call_back"  : get_value,
                 "units"      : "vcl",
                 "description": "N vcl available",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_vcl_discard',
                 "call_back"  : get_value,
                 "units"      : "vcl",
                 "description": "N vcl discarded",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_purge',
                 "call_back"  : get_value,
                 "units"      : "purges",
                 "description": "N total active purges",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_purge_add',
                 "call_back"  : get_delta,
                 "units"      : "purges/sec",
                 "description": "N new purges added",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_purge_retire',
                 "call_back"  : get_delta,
                 "units"      : "purges/s",
                 "description": "N old purges deleted",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_purge_obj_test',
                 "call_back"  : get_delta,
                 "units"      : "purges/s",
                 "description": "N objects tested",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_purge_re_test',
                 "call_back"  : get_delta,
                 "description": "N regexps tested against",
                 "units"      : "purges/s",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_purge_dups',
                 "call_back"  : get_delta,
                 "units"      : "purges/s",
                 "description": "N duplicate purges removed",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'hcb_nolock',
                 "call_back"  : get_delta,
                 "units"      : "locks/s",
                 "description": "HCB Lookups without lock",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'hcb_lock',
                 "call_back"  : get_delta,
                 "units"      : "locks/s",
                 "description": "HCB Lookups with lock",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'hcb_insert',
                 "call_back"  : get_delta,
                 "units"      : "inserts/s",
                 "description": "HCB Inserts",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'esi_parse',
                 "call_back"  : get_delta,
                 "units"      : "obj/s",
                 "description": "Objects ESI parsed (unlock)",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'esi_errors',
                 "call_back"  : get_delta,
                 "units"      : "err/s",
                 "description": "ESI parse errors (unlock)",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'accept_fail',
                 "call_back"  : get_delta,
                 "units"      : "accepts/s",
                 "description": "Accept failures",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'client_drop_late',
                 "call_back"  : get_delta,
                 "units"      : "conn/s",
                 "description": "Connection dropped late",
                 }))
-                
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'uptime',
                 "call_back"  : get_value,
                 "units"      : "seconds",
                 "description": "Client uptime",
                 }))
-                
+
 
     return descriptors
 


### PR DESCRIPTION
Added an exception handler where the value returned from 'varnishstat -1' was a '.'

It is working on Ubuntu 10.04 (two instances) and 11.04 (one instance), with ganglia-monitor from repo (3.1) and varnish 3.0. I didn't have the chance to test with varnish 2.x
