### PR TITLE
nginx_status edge case

### DIFF
--- a/nginx_status/conf.d/nginx_status.pyconf
+++ b/nginx_status/conf.d/nginx_status.pyconf
@@ -6,7 +6,7 @@ modules {
     language = 'python'
 
     param status_url {
-      value = 'http://localhost/nginx_status'
+      value = 'http://nginx_status'
     }
     param nginx_bin {
       value = '/usr/sbin/nginx'


### PR DESCRIPTION
Not sure if this will be useful to others, but this makes nginx_status idempotent. [This nginx-cookbook commit](https://github.com/gchef/nginx-cookbook/commit/1759f2508d18fa5f396f88266e1a0d4edcd14e5a) gives insight into how we're using it. Basically, nginx_status should be a standalone vhost entry which doesn't affect any of the other vhost definitions.
