### PR TITLE
Added per "Consistency Group" replication lag metrics

### DIFF
--- a/recoverpoint/README.mkdn
+++ b/recoverpoint/README.mkdn
@@ -3,6 +3,10 @@ EMC RecoverPoint
 
 This is a GMOND Python Module that gets metrics from EMC RecoverPoint replication appliances.
 
+Currently gathers:
+  * Per RPA WAN/SAN traffic and Latency
+  * Per Consistency Group Write, Data and Time lags.
+
 ## DEPENDS
   * python YAML
   * paramiko modules

--- a/recoverpoint/recoverpoint.pyconf
+++ b/recoverpoint/recoverpoint.pyconf
@@ -24,5 +24,14 @@ collection_group {
     metric {
         name_match = "site2(.+)"
         }
+    metric {
+	name_match = "(.+)Time"
     }
+    metric {
+	name_match = "(.+)Data"
+    }
+    metric {
+	name_match = "(.+)Writes"
+    }
+}
 


### PR DESCRIPTION
Added per consistency group replication lag metrics.  

These metrics are very important for determining how far behind your live storage your replication is.
