### PR TITLE
Ability to read index specific statistics

### DIFF
--- a/elasticsearch/conf.d/elasticsearch.pyconf
+++ b/elasticsearch/conf.d/elasticsearch.pyconf
@@ -9,6 +9,20 @@ modules {
       value = "elasticsearch"
     }
 
+    param host {
+        value = "http://localhost:9200/"
+    }
+
+    # In order to get index specific stats specify each index seperated by
+    # whitespace.
+    # 
+    # indices can be grouped by using comma,
+    # e.g. index3,index4 will give statistics (docs_count, etc.) for both
+    # index1 and index2
+    param indices {
+        value = "*"
+#       value = "index1 index2 index3,index4"
+    }
   }
 }
 


### PR DESCRIPTION
I've added the ability to generate index specific statistics.

With this changes it is possible to get a graph for specific indices that are defined in the pyconf file.
E.g. if you had index1, index2, index3 in a elasticsearch cluster, you could get a docs_count graph for index1 and then another graph for index2 and index3 grouped together.

I've also reformatted the code according to pep8 and reduces the use of globals.
