### PR TITLE
Redis 2.6 support

### DIFF
--- a/redis/python_modules/redis.py
+++ b/redis/python_modules/redis.py
@@ -66,7 +66,6 @@ def metric_init(params={}):
         "expired_keys": {"units": "keys"},
         "pubsub_channels": {"units": "channels"},
         "pubsub_patterns": {"units": "patterns"},
-        "vm_enabled": {"units": "yes/no"},
         "master_last_io_seconds_ago": {"units": "seconds ago"},
     }
     metric_handler.descriptors = {}


### PR DESCRIPTION
Also removes vm_enabled, but it's deprecated in 2.4 and doesn't work at all in 2.6
