### PR TITLE
Change "||" to "or" to avoid syntax error

### DIFF
--- a/gpu/nvidia/python_modules/nvidia.py
+++ b/gpu/nvidia/python_modules/nvidia.py
@@ -99,7 +99,7 @@ def gpu_device_handler(name):
         except NVMLError, nvmlError:
             if NVML_ERROR_NOT_SUPPORTED == nvmlError.value:
                 return 'N/A'
-    elif (metric == 'perf_state' || metric == 'performance_state'):
+    elif (metric == 'perf_state' or metric == 'performance_state'):
         state = nvmlDeviceGetPerformanceState(gpu_device)
         try:
             int(state)


### PR DESCRIPTION
The "logical OR" operator in Python is "or", not "||". The appearance of "||" in nvidia.py prevents the module from loading correctly in gmond. When "||" is changed to "or", the module loads successfully.

This was run on RHEL 6.2 with Python 2.6.6 and Ganglia 3.1.7 from epel.
