### PR TITLE
return empty list when passenger status times out

### DIFF
--- a/passenger/python_modules/passenger.py
+++ b/passenger/python_modules/passenger.py
@@ -192,7 +192,7 @@ def timeout_command(command, timeout):
         if (now - start).seconds> timeout:
             os.system("sudo kill %s" % process.pid)
             os.waitpid(-1, os.WNOHANG)
-            return None
+            return []
     return process.stdout.readlines()
 
 if __name__ == '__main__':


### PR DESCRIPTION
This stops an error from happening when the passenger status command times out.
