### PR TITLE
Bug fix to make sure RabbitMQ module updates with new stats

### DIFF
--- a/rabbit/python_modules/rabbitmq.py
+++ b/rabbit/python_modules/rabbitmq.py
@@ -196,13 +196,6 @@ def metric_init(params):
 
     refreshStats(stats = STATS, vhosts = vhosts)
 
-    def metric_handler(name):
-        if 15 < time.time() - metric_handler.timestamp:
-            metric_handler.timestamp = time.time()
-            return refreshStats(stats = STATS, vhosts = vhosts)
-
-            
-
     def create_desc(prop):
 	d = {
 	    'name'        : 'XXX',


### PR DESCRIPTION
This is my first module, and it had a bug in it that would cause it to collect stats once, then quit. It's now been tested out and seems to work just fine.
