### PR TITLE
Fix mem_total and mem_total_anon in mem_stats.py

### DIFF
--- a/system/mem_stats/python_modules/mem_stats.py
+++ b/system/mem_stats/python_modules/mem_stats.py
@@ -110,7 +110,7 @@ def metric_init(params):
                 }))
 
     descriptors.append(create_desc(Desc_Skel, {
-                "name"       : "mem_total",
+                "name"       : "mem_total_anon",
                 "orig_name"  : "Active(anon)",
                 "units"      : "Bytes",
                 "description": "Active(anon)",


### PR DESCRIPTION
Duplicate mem_total metric name lead to total memory being reported incorrectly
