### PR TITLE
Add support to Python 2.4.

### DIFF
--- a/nginx_status/README.mkdn
+++ b/nginx_status/README.mkdn
@@ -16,12 +16,15 @@ python module for ganglia 3.1.
  * nginx_waiting
 
 ## Params
+
  * status_url (The url to query for nginx status. Default: 'http://localhost/nginx_status')
  * nginx_bin (The full path to the nginx binary. Default '/usr/sbin/nginx')
  * refresh_rate (The time in seconds between polling nginx. Default: 15)
 
 ## NOTES
- * This has only been tested on python 2.6.5 on Ubuntu 10.04.
+
+ * This has been tested on python 2.4.3 on RHEL 5.8.
+ * This has been tested on python 2.6.5 on Ubuntu 10.04.
  * Ensure that the status stub module is setup correctly when using this module.
 
 ## AUTHOR


### PR DESCRIPTION
RHEL 5's default ship with Python 2.4. to use plugins in RHEL 5, must add python 2.4 support.

Changes:
- python 2.4 can not support try..except..finally, use try..except or try..f
  in ally only
- python 2.4's string has no format() method, use % instead.

Tested on Python 2.4.3 / RHEL 5.8.
