### PR TITLE
enhance pep8 report for most scripts

### DIFF
--- a/.pep8
+++ b/.pep8
@@ -1,0 +1,5 @@
+[pep8]
+# E203 whitespace before ':'
+# W191 indentation contains tabs
+ignore = E203,W191
+exclude=./gpu/nvidia/nvidia-ml-py-3.295.00

--- a/apache_status/python_modules/apache_status.py
+++ b/apache_status/python_modules/apache_status.py
@@ -55,6 +55,7 @@ Metric_Map = {
     "Total Accesses" : NAME_PREFIX + "rps"
 }
 
+
 def get_metrics():
 
     global METRICS, LAST_METRICS, SERVER_STATUS_URL, COLLECT_SSL
@@ -66,7 +67,7 @@ def get_metrics():
         # This is the short server-status. Lacks SSL metrics
         try:
             req = urllib2.Request(SERVER_STATUS_URL + "?auto")
-            
+
             # Download the status file
             res = urllib2.urlopen(req, None, 2)
 
@@ -87,14 +88,14 @@ def get_metrics():
              traceback.print_exc()
 
         # If we are collecting SSL metrics we'll do
-        if COLLECT_SSL:    
-    
+        if COLLECT_SSL:
+
             try:
                 req2 = urllib2.Request(SERVER_STATUS_URL)
-                
+
                 # Download the status file
                 res = urllib2.urlopen(req2, None, 2)
-                
+
                 for line in res:
                     regMatch = SSL_REGEX.match(line)
                     if regMatch:
@@ -102,10 +103,9 @@ def get_metrics():
                         for key in linebits:
                             #print SSL_NAME_PREFIX + key + "=" + linebits[key]
                             metrics[SSL_NAME_PREFIX + key] = linebits[key]
-    
+
             except urllib2.URLError:
                  traceback.print_exc()
-
 
         LAST_METRICS = copy.deepcopy(METRICS)
         METRICS = {
@@ -128,6 +128,7 @@ def get_value(name):
 
     return result
 
+
 def get_delta(name):
     """Return change over time for the requested metric"""
 
@@ -146,7 +147,7 @@ def get_delta(name):
 	print name + " is less 0"
 	delta = 0
     except KeyError:
-      delta = 0.0      
+      delta = 0.0
 
     return delta
 
@@ -156,6 +157,7 @@ def create_desc(prop):
     for k,v in prop.iteritems():
         d[k] = v
     return d
+
 
 def metric_init(params):
     global descriptors, Desc_Skel, SERVER_STATUS_URL, COLLECT_SSL
@@ -183,7 +185,7 @@ def metric_init(params):
 
     if "url" not in params:
         params["url"] = "http://localhost:7070/server-status"
-        
+
     if "collect_ssl" not in params:
         params["collect_ssl"] = False
 
@@ -198,7 +200,7 @@ def metric_init(params):
                 "name"       : NAME_PREFIX + "rps",
                 "value_type" : "float",
                 "units"      : "req/sec",
-                "call_back"   : get_delta,                
+                "call_back"   : get_delta,
                 "format"     : "%.3f",
                 "description": "request per second",
                 }))
@@ -207,7 +209,7 @@ def metric_init(params):
                 "name"       : NAME_PREFIX + "bytes",
                 "value_type" : "float",
                 "units"      : "bytes/sec",
-                "call_back"   : get_delta,                
+                "call_back"   : get_delta,
                 "format"     : "%.3f",
                 "description": "bytes transferred per second",
                 }))
@@ -254,12 +256,12 @@ def metric_init(params):
                     "call_back"   : get_value,
                     "description" : v["desc"],
                     }))
-        
+
     ##########################################################################
     # SSL metrics
     ##########################################################################
     if params['collect_ssl']:
-    
+
         descriptors.append(create_desc({
                     "name"       : SSL_NAME_PREFIX + "shared_mem",
                     "value_type" : "float",
@@ -268,7 +270,7 @@ def metric_init(params):
                     "call_back"   : get_value,
                     "description": "Shared memory",
                     }))
-    
+
         descriptors.append(create_desc({
                     "name"       : SSL_NAME_PREFIX + "current_sessions",
                     "value_type" : "uint",
@@ -277,7 +279,7 @@ def metric_init(params):
                     "call_back"   : get_value,
                     "description": "Current sessions",
                     }))
-    
+
         descriptors.append(create_desc({
                     "name"       : SSL_NAME_PREFIX + "num_subcaches",
                     "value_type" : "uint",
@@ -286,7 +288,7 @@ def metric_init(params):
                     "call_back"   : get_value,
                     "description": "Number of subcaches",
                     }))
-    
+
         descriptors.append(create_desc({
                     "name"       : SSL_NAME_PREFIX + "indexes_per_subcache",
                     "value_type" : "float",
@@ -295,8 +297,7 @@ def metric_init(params):
                     "call_back"   : get_value,
                     "description": "Subcaches",
                     }))
-    
-    
+
         descriptors.append(create_desc({
                     "name"       : SSL_NAME_PREFIX + "index_usage",
                     "value_type" : "float",
@@ -305,7 +306,7 @@ def metric_init(params):
                     "call_back"   : get_value,
                     "description": "Index usage",
                     }))
-    
+
         descriptors.append(create_desc({
                     "name"       : SSL_NAME_PREFIX + "cache_usage",
                     "value_type" : "float",
@@ -314,8 +315,7 @@ def metric_init(params):
                     "call_back"   : get_value,
                     "description": "Cache usage",
                     }))
-    
-    
+
         descriptors.append(create_desc({
                     "name"       : SSL_NAME_PREFIX + "sessions_stored",
                     "value_type" : "float",
@@ -324,7 +324,7 @@ def metric_init(params):
                     "call_back"   : get_delta,
                     "description": "Sessions stored",
                     }))
-    
+
         descriptors.append(create_desc({
                     "name"       : SSL_NAME_PREFIX + "sessions_expired",
                     "value_type" : "float",
@@ -333,7 +333,7 @@ def metric_init(params):
                     "call_back"   : get_delta,
                     "description": "Sessions expired",
                     }))
-    
+
         descriptors.append(create_desc({
                     "name"       : SSL_NAME_PREFIX + "retrieves_hit",
                     "value_type" : "float",
@@ -342,7 +342,7 @@ def metric_init(params):
                     "call_back"   : get_delta,
                     "description": "Retrieves Hit",
                     }))
-    
+
         descriptors.append(create_desc({
                     "name"       : SSL_NAME_PREFIX + "retrieves_miss",
                     "value_type" : "float",
@@ -351,7 +351,7 @@ def metric_init(params):
                     "call_back"   : get_delta,
                     "description": "Retrieves Miss",
                     }))
-    
+
         descriptors.append(create_desc({
                     "name"       : SSL_NAME_PREFIX + "removes_hit",
                     "value_type" : "float",
@@ -360,7 +360,7 @@ def metric_init(params):
                     "call_back"   : get_delta,
                     "description": "Removes Hit",
                     }))
-    
+
         descriptors.append(create_desc({
                     "name"       : SSL_NAME_PREFIX + "removes_miss",
                     "value_type" : "float",
@@ -371,6 +371,7 @@ def metric_init(params):
                     }))
 
     return descriptors
+
 
 def metric_cleanup():
     '''Clean up the metric module.'''

--- a/apc_status/python_modules/apc_status.py
+++ b/apc_status/python_modules/apc_status.py
@@ -21,22 +21,23 @@ APC_STATUS_URL = ""
 descriptors = list()
 Desc_Skel   = {}
 metric_list = {
-	NAME_PREFIX + 'num_slots'	: { 'type': 'uint',  'format' : '%d', 'unit': 'Slots', 		'desc': 'Number of slots' },
-	NAME_PREFIX + 'num_hits'	: { 'type': 'uint',  'format' : '%d', 'unit': 'Hits', 		'desc': 'Number of cache hits' },
-	NAME_PREFIX + 'num_misses'	: { 'type': 'uint',  'format' : '%d', 'unit': 'Misses', 	'desc': 'Number of cache misses' },
-	NAME_PREFIX + 'num_inserts'	: { 'type': 'uint',  'format' : '%d', 'unit': 'Inserts', 	'desc': 'Number of cache inserts' },
-	NAME_PREFIX + 'expunges'	: { 'type': 'uint',  'format' : '%d', 'unit': 'Deletes', 	'desc': 'Number of cache deletes' },
-	NAME_PREFIX + 'mem_size'	: { 'type': 'uint',  'format' : '%d', 'unit': 'Bytes', 		'desc': 'Memory size' },
-	NAME_PREFIX + 'num_entries'	: { 'type': 'uint',  'format' : '%d', 'unit': 'Entries', 	'desc': 'Cached Files' },
-	NAME_PREFIX + 'uptime'		: { 'type': 'uint',  'format' : '%d', 'unit': 'seconds',	'desc': 'Uptime' },
-	NAME_PREFIX + 'request_rate'	: { 'type': 'float', 'format' : '%f', 'unit': 'requests/sec', 	'desc': 'Request Rate (hits, misses)' },
-	NAME_PREFIX + 'hit_rate'	: { 'type': 'float', 'format' : '%f', 'unit': 'requests/sec', 	'desc': 'Hit Rate' },
-	NAME_PREFIX + 'miss_rate'	: { 'type': 'float', 'format' : '%f', 'unit': 'requests/sec', 	'desc': 'Miss Rate' },
-	NAME_PREFIX + 'insert_rate'	: { 'type': 'float', 'format' : '%f', 'unit': 'requests/sec', 	'desc': 'Insert Rate' },
-	NAME_PREFIX + 'num_seg'		: { 'type': 'uint',  'format' : '%d', 'unit': 'fragments', 	'desc': 'Segments' },
-	NAME_PREFIX + 'mem_avail'	: { 'type': 'uint',  'format' : '%d', 'unit': 'bytes', 		'desc': 'Free Memory' },
-	NAME_PREFIX + 'mem_used'	: { 'type': 'uint',  'format' : '%d', 'unit': 'bytes', 		'desc': 'Used Memory' },
+	NAME_PREFIX + 'num_slots'   : { 'type': 'uint',  'format' : '%d', 'unit': 'Slots',        'desc': 'Number of slots' },
+	NAME_PREFIX + 'num_hits'    : { 'type': 'uint',  'format' : '%d', 'unit': 'Hits',         'desc': 'Number of cache hits' },
+	NAME_PREFIX + 'num_misses'  : { 'type': 'uint',  'format' : '%d', 'unit': 'Misses',       'desc': 'Number of cache misses' },
+	NAME_PREFIX + 'num_inserts' : { 'type': 'uint',  'format' : '%d', 'unit': 'Inserts',      'desc': 'Number of cache inserts' },
+	NAME_PREFIX + 'expunges'    : { 'type': 'uint',  'format' : '%d', 'unit': 'Deletes',      'desc': 'Number of cache deletes' },
+	NAME_PREFIX + 'mem_size'    : { 'type': 'uint',  'format' : '%d', 'unit': 'Bytes',        'desc': 'Memory size' },
+	NAME_PREFIX + 'num_entries' : { 'type': 'uint',  'format' : '%d', 'unit': 'Entries',      'desc': 'Cached Files' },
+	NAME_PREFIX + 'uptime'      : { 'type': 'uint',  'format' : '%d', 'unit': 'seconds',      'desc': 'Uptime' },
+	NAME_PREFIX + 'request_rate': { 'type': 'float', 'format' : '%f', 'unit': 'requests/sec', 'desc': 'Request Rate (hits, misses)' },
+	NAME_PREFIX + 'hit_rate'    : { 'type': 'float', 'format' : '%f', 'unit': 'requests/sec', 'desc': 'Hit Rate' },
+	NAME_PREFIX + 'miss_rate'   : { 'type': 'float', 'format' : '%f', 'unit': 'requests/sec', 'desc': 'Miss Rate' },
+	NAME_PREFIX + 'insert_rate' : { 'type': 'float', 'format' : '%f', 'unit': 'requests/sec', 'desc': 'Insert Rate' },
+	NAME_PREFIX + 'num_seg'     : { 'type': 'uint',  'format' : '%d', 'unit': 'fragments',    'desc': 'Segments' },
+	NAME_PREFIX + 'mem_avail'   : { 'type': 'uint',  'format' : '%d', 'unit': 'bytes',        'desc': 'Free Memory' },
+	NAME_PREFIX + 'mem_used'    : { 'type': 'uint',  'format' : '%d', 'unit': 'bytes',        'desc': 'Used Memory' },
 	}
+
 
 def get_value(name):
 	try:
@@ -50,11 +51,13 @@ def get_value(name):
 
 	return apc_stats[name[len(NAME_PREFIX):]]
 
+
 def create_desc(prop):
 	d = Desc_Skel.copy()
 	for k,v in prop.iteritems():
 		d[k] = v
 	return d
+
 
 def metric_init(params):
 	global descriptors, Desc_Skel, APC_STATUS_URL
@@ -79,8 +82,7 @@ def metric_init(params):
 
 	if "url" not in params:
 		params["url"] = "http://localhost/apc-json.php"
-	
-	
+
 	APC_STATUS_URL = params["url"]
 
 	if "spoof_host" in params:
@@ -98,6 +100,7 @@ def metric_init(params):
 
 	return descriptors
 
+
 def metric_cleanup():
 	pass
 
@@ -106,5 +109,3 @@ if __name__ == '__main__':
 	for d in descriptors:
 		v = d['call_back'](d['name'])
 		print 'value for %s is %s' % (d['name'], v)
-
-

--- a/beanstalk/python_modules/beanstalk.py
+++ b/beanstalk/python_modules/beanstalk.py
@@ -4,14 +4,18 @@ import beanstalkc
 
 HOST='localhost'
 PORT=14711
+
+
 def stat_handler(name):
     bean=beanstalkc.Connection(host=HOST,port=PORT)
     return bean.stats()[name]
-    
+
+
 def tube_stat_handler(name):
     bean=beanstalkc.Connection(host=HOST,port=PORT)
     return bean.stats_tube(name.split('_')[0])[name.split('_')[1]]
-    
+
+
 def metric_init(params):
     global descriptors
 
@@ -88,7 +92,7 @@ def metric_init(params):
             'description': 'Number of Beanstalkd Burries',
             'groups': 'beanstalkd'}
         ]
-        
+
     #now get all the tubes
     bean=beanstalkc.Connection(host=HOST,port=PORT)
     tubes=bean.tubes()
@@ -143,8 +147,9 @@ def metric_init(params):
             'format': '%u',
             'description': 'Current Number of Jobs Waiting ('+tube+')',
             'groups': 'beanstalkd'})
-    
+
     return descriptors
+
 
 def metric_cleanup():
     '''Clean up the metric module.'''

--- a/blueeyes_service/python_modules/blueeyes_service.py
+++ b/blueeyes_service/python_modules/blueeyes_service.py
@@ -75,8 +75,8 @@ def get_metrics():
         io = os.popen(PARAMS['stats_command'])
 
         # clean up
-        metrics_str = ''.join(io.readlines()).strip() # convert to string
-        metrics_str = re.sub('\w+\((.*)\)', r"\1", metrics_str) # remove functions
+        metrics_str = ''.join(io.readlines()).strip()  # convert to string
+        metrics_str = re.sub('\w+\((.*)\)', r"\1", metrics_str)  # remove functions
 
         # convert to flattened dict
         try:
@@ -99,7 +99,7 @@ def get_value(name):
 
     metrics = get_metrics()[0]
 
-    name = name[len(NAME_PREFIX):] # remove prefix from name
+    name = name[len(NAME_PREFIX):]  # remove prefix from name
     try:
         result = metrics['data'][name]
     except StandardError:
@@ -115,7 +115,7 @@ def get_rate(name):
     [curr_metrics, last_metrics] = get_metrics()
 
     # get delta
-    name = name[len(NAME_PREFIX):] # remove prefix from name
+    name = name[len(NAME_PREFIX):]  # remove prefix from name
     try:
         delta = (curr_metrics['data'][name] - last_metrics['data'][name])/(curr_metrics['time'] - last_metrics['time'])
         if delta < 0:

--- a/couchdb/python_modules/couchdb.py
+++ b/couchdb/python_modules/couchdb.py
@@ -16,6 +16,7 @@ logging.basicConfig(level=logging.ERROR)
 
 _Worker_Thread = None
 
+
 class UpdateCouchdbThread(threading.Thread):
 
     def __init__(self, params):
@@ -144,6 +145,7 @@ class UpdateCouchdbThread(threading.Thread):
             logging.warning('failed to fetch ' + name)
             return 0
 
+
 def metric_init(params):
     logging.debug('init: ' + str(params))
     global _Worker_Thread
@@ -267,13 +269,16 @@ def metric_init(params):
 
     return descriptors
 
+
 def metric_of(name):
     global _Worker_Thread
     return _Worker_Thread.metric_of(name)
 
+
 def setting_of(name):
     global _Worker_Thread
     return _Worker_Thread.setting_of(name)
+
 
 def metric_cleanup():
     global _Worker_Thread

--- a/diskfree/python_modules/diskfree.py
+++ b/diskfree/python_modules/diskfree.py
@@ -54,7 +54,7 @@ def get_value(name):
         if unit_type == 'percent':
             result = (float(disk.f_bavail) / float(disk.f_blocks)) * 100
         else:
-            result = (disk.f_bavail * disk.f_frsize) / float(2**30) # GB
+            result = (disk.f_bavail * disk.f_frsize) / float(2**30)  # GB
 
     except OSError:
         result = 0
@@ -92,14 +92,14 @@ def metric_init(lparams):
                 path_key = 'rootfs'
             else:
                 path_key = mount_info[1][1:].replace('/', '_')
-                
+
             # Calculate the size of the disk. We'll use it exclude small disks
-            disk = os.statvfs(mount_info[1])            
+            disk = os.statvfs(mount_info[1])
             disk_size = (disk.f_blocks * disk.f_frsize) / float(2**30)
 
             if disk_size > MIN_DISK_SIZE and mount_info[1] != "/dev":
 	      for unit_type in ['absolute', 'percent']:
-		  if unit_type == 'percent': 
+		  if unit_type == 'percent':
 			  units = '%'
 		  else:
 			  units = 'GB'

--- a/diskpart/python_modules/diskpart.py
+++ b/diskpart/python_modules/diskpart.py
@@ -10,7 +10,8 @@ descriptors = list()
 mount_points = list()
 Desc_Skel   = {}
 _Worker_Thread = None
-_Lock = threading.Lock() # synchronization lock
+_Lock = threading.Lock()  # synchronization lock
+
 
 class UpdateMetricThread(threading.Thread):
 
@@ -55,7 +56,6 @@ class UpdateMetricThread(threading.Thread):
             self.metric[ part+"-inode-total" ] = st.f_files
             self.metric[ part+"-inode-used"  ] = st.f_files - st.f_favail
 
-
     def metric_of(self, name):
         val = 0
         if name in self.metric:
@@ -64,12 +64,14 @@ class UpdateMetricThread(threading.Thread):
             _Lock.release()
         return val
 
+
 def is_remotefs(dev, type):
     if dev.find(":") >= 0:
         return True
     elif dev.startswith("//") and (type == "smbfs" or type == "cifs"):
         return True
     return False
+
 
 def metric_init(params):
     global descriptors, Desc_Skel, _Worker_Thread, mount_points
@@ -107,7 +109,7 @@ def metric_init(params):
         elif opt.startswith('ro'):
             continue
         elif not dev.startswith('/dev/') \
-          and not (mtp == "/" and fstype == "tmpfs"): # for netboot
+          and not (mtp == "/" and fstype == "tmpfs"):  # for netboot
             continue;
 
         if mtp == "/":
@@ -147,14 +149,17 @@ def metric_init(params):
 
     return descriptors
 
+
 def create_desc(skel, prop):
     d = skel.copy()
     for k,v in prop.iteritems():
         d[k] = v
     return d
 
+
 def metric_of(name):
     return _Worker_Thread.metric_of(name)
+
 
 def metric_cleanup():
     _Worker_Thread.shutdown()
@@ -175,4 +180,3 @@ if __name__ == '__main__':
     except:
         print sys.exc_info()[0]
         raise
-

--- a/ehcache/python_modules/ehcache.py
+++ b/ehcache/python_modules/ehcache.py
@@ -39,10 +39,11 @@ NAME = PORT
 MAX_UPDATE_TIME = 15
 JMXSH = '/usr/share/java/jmxsh.jar'
 
+
 def update_stats():
 	logging.debug('updating stats')
 	global last_update, stats, last_val
-	
+
 	cur_time = time.time()
 
 	if cur_time - last_update < MAX_UPDATE_TIME:
@@ -59,7 +60,7 @@ def update_stats():
 		sh += 'puts "' + name + '_miss_count: [jmx_get -m ' + _mbean + mbean_name + ' CacheMissCount]"\n'
 
 	#logging.debug(sh)
-	
+
 	try:
 		# run jmxsh.jar with the temp file as a script
 		cmd = "java -jar " + JMXSH + " -q"
@@ -105,6 +106,7 @@ def update_stats():
 	last_update = cur_time
 	return True
 
+
 def get_stat(name):
 	logging.debug('getting stat: ' + name)
 
@@ -125,6 +127,7 @@ def get_stat(name):
 	else:
 		return 0
 
+
 def metric_init(params):
 	global descriptors
 	global METRICS,HOST,PORT,NAME
@@ -135,7 +138,7 @@ def metric_init(params):
 		HOST = params.pop('host')
 		PORT = params.pop('port')
 		NAME = params.pop('name')
-		
+
 	except:
 		logging.warning('Incorrect parameters')
 
@@ -176,6 +179,7 @@ def metric_init(params):
 
 	return descriptors
 
+
 def metric_cleanup():
 	logging.shutdown()
 	# pass
@@ -204,7 +208,7 @@ if __name__ == '__main__':
 	for name in _param:
 		params[name] = _val[i]
 		i += 1
-	
+
 	metric_init(params)
 
 	if options.test:
@@ -227,4 +231,3 @@ if __name__ == '__main__':
 			cmd = "%s --conf=%s --value='%s' --units='%s' --type='%s' --name='%s' --slope='%s'" % \
 				(options.gmetric_bin, options.gmond_conf, v, d['units'], value_type, d['name'], d['slope'])
 			os.system(cmd)
-

--- a/fibrechannel/fibrechannel.py
+++ b/fibrechannel/fibrechannel.py
@@ -33,6 +33,7 @@ oidDict = {
     'ifOutErrors'    : (1,3,6,1,2,1,2,2,1,20),
     }
 
+
 def get_metrics():
     """Return all metrics"""
 
@@ -57,6 +58,7 @@ def get_metrics():
 
     return [NIMETRICS, LAST_NIMETRICS]
 
+
 def get_delta(name):
     """Return change over time for the requested metric"""
 
@@ -73,9 +75,10 @@ def get_delta(name):
 
     return delta
 
+
 # Separate routine to perform SNMP queries and returns table (dict)
 def runSnmp(oidDict,ip):
-    
+
     # cmdgen only takes tuples, oid strings don't work
 
 #    'ifIndex'       : (1,3,6,1,2,1,2,2,1,1),
@@ -113,18 +116,19 @@ def runSnmp(oidDict,ip):
         else:
             return(varBindTable)
 
-def buildDict(oidDict,t,switch): # passed a list of tuples, build's a dict based on the alias name
+
+def buildDict(oidDict,t,switch):  # passed a list of tuples, build's a dict based on the alias name
     builtdict = {}
-    
+
     for line in t:
         #        if t[t.index(line)][2][1] != '':
-        string = str(t[t.index(line)][1][1]) # this is the ifDescr 
+        string = str(t[t.index(line)][1][1])  # this is the ifDescr
         #print string
         match = re.search(r'FC port', string)
         if match and t[t.index(line)][0][1] != '':
             #alias = str(t[t.index(line)][0][1])
             index = str(t[t.index(line)][0][1])
-            temp = str(t[t.index(line)][1][1]) #(use ifDescr)
+            temp = str(t[t.index(line)][1][1])  # (use ifDescr)
             #lowercase the name, change spaces + '/' to '_'
             name = ((temp.lower()).replace(' ','_')).replace('/','_')
             inoct = str(t[t.index(line)][2][1])
@@ -139,9 +143,10 @@ def buildDict(oidDict,t,switch): # passed a list of tuples, build's a dict based
             builtdict[switch+'_'+name+'_inerrors'] = int(inerrors)
             outerrors = str(t[t.index(line)][6][1])
             builtdict[switch+'_'+name+'_outerrors'] = int(outerrors)
-                         
+
     #pprint.pprint(builtdict)
     return builtdict
+
 
 # define_metrics will run an snmp query on an ipaddr, find interfaces, build descriptors and set spoof_host
 # define_metrics is called from metric_init
@@ -202,8 +207,8 @@ def define_metrics(Desc_Skel, ipaddr, switch):
                         "spoof_host"  : spoof_string,
                         }))
 
-
     return descriptors
+
 
 def metric_init(params):
     global descriptors, Desc_Skel, _Worker_Thread, Debug, newdict
@@ -225,9 +230,9 @@ def metric_init(params):
         'slope'       : 'both',
         'description' : 'XXX',
         'groups'      : 'switch',
-        }  
+        }
 
-    # Find all the switch's passed in params    
+    # Find all the switch's passed in params
     for para in params.keys():
          if para.startswith('switch_'):
              #Get ipaddr + name of switchs from params
@@ -236,6 +241,7 @@ def metric_init(params):
              descriptors = define_metrics(Desc_Skel, ipaddr, name)
     #Return the descriptors back to gmond
     return descriptors
+
 
 def create_desc(skel, prop):
     d = skel.copy()
@@ -259,7 +265,7 @@ if __name__ == '__main__':
     while True:
         for d in descriptors:
             v = d['call_back'](d['name'])
-            print 'value for %s is %u' % (d['name'],  v)        
+            print 'value for %s is %u' % (d['name'],  v)
         print 'Sleeping 5 seconds'
         time.sleep(5)
 #exit(0)

--- a/gpu/nvidia/python_modules/nvidia.py
+++ b/gpu/nvidia/python_modules/nvidia.py
@@ -53,14 +53,18 @@ def build_descriptor(name, call_back, time_max, value_type, units, slope, format
         print "Failed to build descriptor :", name, ":", str(err)
         pass
 
+
 def get_gpu_num():
     return int(nvmlDeviceGetCount())
+
 
 def gpu_num_handler(name):
     return get_gpu_num()
 
+
 def gpu_driver_version_handler(name):
     return nvmlSystemGetDriverVersion()
+
 
 def gpu_device_handler(name):
     d = find_descriptor(name)
@@ -136,6 +140,7 @@ def gpu_device_handler(name):
         print "Handler for %s not implemented, please fix in gpu_device_handler()" % metric
         os._exit(1)
 
+
 def metric_init(params):
     global descriptors
 
@@ -150,7 +155,7 @@ def metric_init(params):
 
     build_descriptor('gpu_num', gpu_num_handler, default_time_max, 'uint', 'GPUs', 'zero', '%u', 'Total number of GPUs', 'gpu')
     build_descriptor('gpu_driver', gpu_driver_version_handler, default_time_max, 'string', '', 'zero', '%s', 'GPU Driver Version', 'gpu')
- 
+
     for i in range(get_gpu_num()):
         build_descriptor('gpu%s_type' % i, gpu_device_handler, default_time_max, 'string', '', 'zero', '%s', 'GPU%s Type' % i, 'gpu')
         build_descriptor('gpu%s_graphics_speed' % i, gpu_device_handler, default_time_max, 'uint', 'MHz', 'both', '%u', 'GPU%s Graphics Speed' % i, 'gpu')
@@ -180,6 +185,7 @@ def metric_init(params):
         build_descriptor('gpu%s_power_man_limit' % i, gpu_device_handler, default_time_max, 'string', '', 'zero', '%s', 'GPU%s Power Management Limit' % i, 'gpu')
 
     return descriptors
+
 
 def metric_cleanup():
     '''Clean up the metric module.'''

--- a/httpd/python_modules/httpd.py
+++ b/httpd/python_modules/httpd.py
@@ -57,10 +57,11 @@ MAX_UPDATE_TIME = 15
 
 #SCOREBOARD_KEY = ('_', 'S', 'R', 'W', 'K', 'D', 'C', 'L', 'G', 'I', '.')
 
+
 def update_stats():
 	logging.debug('updating stats')
 	global last_update, httpd_stats, httpd_stats_last
-	
+
 	cur_time = time.time()
 
 	if cur_time - last_update < MAX_UPDATE_TIME:
@@ -148,6 +149,7 @@ def update_stats():
 
 	return True
 
+
 def update_server_stats():
 	logging.debug('updating server stats')
 	global last_update_server, server_stats
@@ -227,11 +229,11 @@ def update_server_stats():
 			if len(line) == 2:
 				server_stats[key] = int(line[1])
 
-
 	logging.debug('success refreshing server stats')
 	logging.debug('server_stats: ' + str(server_stats))
 
 	return True
+
 
 def get_stat(name):
 	logging.debug('getting stat: ' + name)
@@ -252,6 +254,7 @@ def get_stat(name):
 	else:
 		return 0
 
+
 def get_server_stat(name):
 	logging.debug('getting server stat: ' + name)
 
@@ -271,19 +274,20 @@ def get_server_stat(name):
 	else:
 		return 0
 
+
 def metric_init(params):
 	global descriptors
 
 	global STATUS_URL, APACHE_CONF, APACHE_CTL, APACHE_BIN, APACHE_USER
 	global REPORT_EXTENDED, REPORT_PREFORK
 
-	STATUS_URL	= params.get('status_url')
-	APACHE_CONF	= params.get('apache_conf')
-	APACHE_CTL	= params.get('apache_ctl').replace('/','\/')
-	APACHE_BIN	= params.get('apache_bin').replace('/','\/')
-	APACHE_USER	= params.get('apache_user')
+	STATUS_URL  = params.get('status_url')
+	APACHE_CONF = params.get('apache_conf')
+	APACHE_CTL  = params.get('apache_ctl').replace('/','\/')
+	APACHE_BIN  = params.get('apache_bin').replace('/','\/')
+	APACHE_USER = params.get('apache_user')
 	REPORT_EXTENDED = str(params.get('get_extended', True)) == 'True'
-	REPORT_PREFORK	 = str(params.get('get_prefork', True)) == 'True'
+	REPORT_PREFORK  = str(params.get('get_prefork', True)) == 'True'
 
 	logging.debug('init: ' + str(params))
 
@@ -402,6 +406,7 @@ def metric_init(params):
 
 	return descriptors
 
+
 def metric_cleanup():
 	logging.shutdown()
 	# pass
@@ -416,7 +421,7 @@ if __name__ == '__main__':
 	parser.add_option('-a', '--apache-conf', dest='apache_conf', default='/etc/httpd/conf/httpd.conf', help='path to httpd.conf')
 	parser.add_option('-t', '--apache-ctl', dest='apache_ctl', default='/usr/sbin/apachectl', help='path to apachectl')
 	parser.add_option('-d', '--apache-bin', dest='apache_bin', default='/usr/sbin/httpd', help='path to httpd')
-	parser.add_option('-u', '--apache-user', dest='apache_user', default='apache', help='username that runs httpd')        
+	parser.add_option('-u', '--apache-user', dest='apache_user', default='apache', help='username that runs httpd')
 	parser.add_option('-e', '--extended', dest='get_extended', action='store_true', default=False)
 	parser.add_option('-p', '--prefork', dest='get_prefork', action='store_true', default=False)
 	parser.add_option('-b', '--gmetric-bin', dest='gmetric_bin', default='/usr/bin/gmetric', help='path to gmetric binary')
@@ -450,4 +455,3 @@ if __name__ == '__main__':
 			cmd = "%s --conf=%s --value='%s' --units='%s' --type='%s' --name='%s' --slope='%s'" % \
 				(options.gmetric_bin, options.gmond_conf, v, d['units'], value_type, d['name'], d['slope'])
 			os.system(cmd)
-

--- a/infobright/python_modules/infobright.py
+++ b/infobright/python_modules/infobright.py
@@ -56,6 +56,7 @@ REPORT_SLAVE  = True
 
 MAX_UPDATE_TIME = 15
 
+
 def update_stats(get_brighthouse=True, get_brighthouse_engine=True, get_master=True, get_slave=True):
 	"""
 
@@ -118,7 +119,7 @@ def update_stats(get_brighthouse=True, get_brighthouse_engine=True, get_master=T
 
 		if get_brighthouse_engine:
 			logging.warn('get_brighthouse_engine status not implemented')
-			
+
 		master_logs = tuple
 		if get_master:
 			cursor = conn.cursor(MySQLdb.cursors.Cursor)
@@ -228,7 +229,7 @@ def update_stats(get_brighthouse=True, get_brighthouse_engine=True, get_master=T
 		'threads_running',
 		'uptime'
 	)
-	
+
 	interesting_brighthouse_status_vars = (
 		'bh_gdc_false_wakeup',
 		'bh_gdc_hits',
@@ -267,7 +268,7 @@ def update_stats(get_brighthouse=True, get_brighthouse_engine=True, get_master=T
 		'bh_writebytes',
 		'bh_writecount',
 	)
-	
+
 	non_delta_brighthouse_status_vars = (
 		'bh_gdc_read_wait_in_progress',
 		'bh_mm_alloc_size',
@@ -325,9 +326,9 @@ def update_stats(get_brighthouse=True, get_brighthouse_engine=True, get_master=T
 		infobright_stats['slave_relay_log_pos'] = slave_status['relay_log_pos']
 		infobright_stats['slave_relay_log_space'] = slave_status['relay_log_space']
 
-
 	logging.debug('success updating stats')
 	logging.debug('infobright_stats: ' + str(infobright_stats))
+
 
 def get_stat(name):
 	logging.info("getting stat: %s" % name)
@@ -356,6 +357,7 @@ def get_stat(name):
 			return 0
 	else:
 		return 0
+
 
 def metric_init(params):
 	global descriptors
@@ -400,121 +402,121 @@ def metric_init(params):
 			'description': 'The number of connections that were aborted because the client died without closing the connection properly',
 			'value_type': 'float',
 			'units': 'clients',
-		}, 
+		},
 
 		aborted_connects = {
 			'description': 'The number of failed attempts to connect to the Infobright server',
 			'value_type': 'float',
 			'units': 'conns',
-		}, 
+		},
 
 		binlog_cache_disk_use = {
 			'description': 'The number of transactions that used the temporary binary log cache but that exceeded the value of binlog_cache_size and used a temporary file to store statements from the transaction',
 			'value_type': 'float',
 			'units': 'txns',
-		}, 
+		},
 
 		binlog_cache_use = {
 			'description': ' The number of transactions that used the temporary binary log cache',
 			'value_type': 'float',
 			'units': 'txns',
-		}, 
+		},
 
 		bytes_received = {
 			'description': 'The number of bytes received from all clients',
 			'value_type': 'float',
 			'units': 'bytes',
-		}, 
+		},
 
 		bytes_sent = {
 			'description': ' The number of bytes sent to all clients',
 			'value_type': 'float',
 			'units': 'bytes',
-		}, 
+		},
 
 		com_delete = {
 			'description': 'The number of DELETE statements',
 			'value_type': 'float',
 			'units': 'stmts',
-		}, 
+		},
 
 		com_delete_multi = {
 			'description': 'The number of multi-table DELETE statements',
 			'value_type': 'float',
 			'units': 'stmts',
-		}, 
+		},
 
 		com_insert = {
 			'description': 'The number of INSERT statements',
 			'value_type': 'float',
 			'units': 'stmts',
-		}, 
+		},
 
 		com_insert_select = {
 			'description': 'The number of INSERT ... SELECT statements',
 			'value_type': 'float',
 			'units': 'stmts',
-		}, 
+		},
 
 		com_load = {
 			'description': 'The number of LOAD statements',
 			'value_type': 'float',
 			'units': 'stmts',
-		}, 
+		},
 
 		com_replace = {
 			'description': 'The number of REPLACE statements',
 			'value_type': 'float',
 			'units': 'stmts',
-		}, 
+		},
 
 		com_replace_select = {
 			'description': 'The number of REPLACE ... SELECT statements',
 			'value_type': 'float',
 			'units': 'stmts',
-		}, 
+		},
 
 		com_select = {
 			'description': 'The number of SELECT statements',
 			'value_type': 'float',
 			'units': 'stmts',
-		}, 
+		},
 
 		com_update = {
 			'description': 'The number of UPDATE statements',
 			'value_type': 'float',
 			'units': 'stmts',
-		}, 
+		},
 
 		com_update_multi = {
 			'description': 'The number of multi-table UPDATE statements',
 			'value_type': 'float',
 			'units': 'stmts',
-		}, 
+		},
 
 		connections = {
 			'description': 'The number of connection attempts (successful or not) to the Infobright server',
 			'value_type': 'float',
 			'units': 'conns',
-		}, 
+		},
 
 		created_tmp_disk_tables = {
 			'description': 'The number of temporary tables on disk created automatically by the server while executing statements',
 			'value_type': 'float',
 			'units': 'tables',
-		}, 
+		},
 
 		created_tmp_files = {
 			'description': 'The number of temporary files Infobrights mysqld has created',
 			'value_type': 'float',
 			'units': 'files',
-		}, 
+		},
 
 		created_tmp_tables = {
 			'description': 'The number of in-memory temporary tables created automatically by the server while executing statement',
 			'value_type': 'float',
 			'units': 'tables',
-		}, 
+		},
 
 		#TODO in graphs: key_read_cache_miss_rate = key_reads / key_read_requests
 
@@ -522,224 +524,224 @@ def metric_init(params):
 			'description': 'The number of requests to read a key block from the cache',
 			'value_type': 'float',
 			'units': 'reqs',
-		}, 
+		},
 
 		key_reads = {
 			'description': 'The number of physical reads of a key block from disk',
 			'value_type': 'float',
 			'units': 'reads',
-		}, 
+		},
 
 		key_write_requests = {
 			'description': 'The number of requests to write a key block to the cache',
 			'value_type': 'float',
 			'units': 'reqs',
-		}, 
+		},
 
 		key_writes = {
 			'description': 'The number of physical writes of a key block to disk',
 			'value_type': 'float',
 			'units': 'writes',
-		}, 
+		},
 
 		max_used_connections = {
 			'description': 'The maximum number of connections that have been in use simultaneously since the server started',
 			'units': 'conns',
 			'slope': 'both',
-		}, 
+		},
 
 		open_files = {
 			'description': 'The number of files that are open',
 			'units': 'files',
 			'slope': 'both',
-		}, 
+		},
 
 		open_tables = {
 			'description': 'The number of tables that are open',
 			'units': 'tables',
 			'slope': 'both',
-		}, 
+		},
 
-		# If Opened_tables is big, your table_cache value is probably too small. 
+		# If Opened_tables is big, your table_cache value is probably too small.
 		opened_tables = {
 			'description': 'The number of tables that have been opened',
 			'value_type': 'float',
 			'units': 'tables',
-		}, 
+		},
 
 		qcache_free_blocks = {
 			'description': 'The number of free memory blocks in the query cache',
 			'units': 'blocks',
 			'slope': 'both',
-		}, 
+		},
 
 		qcache_free_memory = {
 			'description': 'The amount of free memory for the query cache',
 			'units': 'bytes',
 			'slope': 'both',
-		}, 
+		},
 
 		qcache_hits = {
 			'description': 'The number of query cache hits',
 			'value_type': 'float',
 			'units': 'hits',
-		}, 
+		},
 
 		qcache_inserts = {
 			'description': 'The number of queries added to the query cache',
 			'value_type': 'float',
 			'units': 'queries',
-		}, 
+		},
 
 		qcache_lowmem_prunes = {
 			'description': 'The number of queries that were deleted from the query cache because of low memory',
 			'value_type': 'float',
 			'units': 'queries',
-		}, 
+		},
 
 		qcache_not_cached = {
 			'description': 'The number of non-cached queries (not cacheable, or not cached due to the query_cache_type setting)',
 			'value_type': 'float',
 			'units': 'queries',
-		}, 
+		},
 
 		qcache_queries_in_cache = {
 			'description': 'The number of queries registered in the query cache',
 			'value_type': 'float',
 			'units': 'queries',
-		}, 
+		},
 
 		qcache_total_blocks = {
 			'description': 'The total number of blocks in the query cache',
 			'units': 'blocks',
-		}, 
+		},
 
 		questions = {
 			'description': 'The number of statements that clients have sent to the server',
 			'value_type': 'float',
 			'units': 'stmts',
-		}, 
+		},
 
 		# If this value is not 0, you should carefully check the indexes of your tables.
 		select_full_join = {
 			'description': 'The number of joins that perform table scans because they do not use indexes',
 			'value_type': 'float',
 			'units': 'joins',
-		}, 
+		},
 
 		select_full_range_join = {
 			'description': 'The number of joins that used a range search on a reference table',
 			'value_type': 'float',
 			'units': 'joins',
-		}, 
+		},
 
 		select_range = {
 			'description': 'The number of joins that used ranges on the first table',
 			'value_type': 'float',
 			'units': 'joins',
-		}, 
+		},
 
 		# If this is not 0, you should carefully check the indexes of your tables.
 		select_range_check = {
 			'description': 'The number of joins without keys that check for key usage after each row',
 			'value_type': 'float',
 			'units': 'joins',
-		}, 
+		},
 
 		select_scan = {
 			'description': 'The number of joins that did a full scan of the first table',
 			'value_type': 'float',
 			'units': 'joins',
-		}, 
+		},
 
 		slave_open_temp_tables = {
 			'description': 'The number of temporary tables that the slave SQL thread currently has open',
 			'value_type': 'float',
 			'units': 'tables',
 			'slope': 'both',
-		}, 
+		},
 
 		slave_retried_transactions = {
 			'description': 'The total number of times since startup that the replication slave SQL thread has retried transactions',
 			'value_type': 'float',
 			'units': 'count',
-		}, 
+		},
 
 		slow_launch_threads = {
 			'description': 'The number of threads that have taken more than slow_launch_time seconds to create',
 			'value_type': 'float',
 			'units': 'threads',
-		}, 
+		},
 
 		slow_queries = {
 			'description': 'The number of queries that have taken more than long_query_time seconds',
 			'value_type': 'float',
 			'units': 'queries',
-		}, 
+		},
 
 		sort_range = {
 			'description': 'The number of sorts that were done using ranges',
 			'value_type': 'float',
 			'units': 'sorts',
-		}, 
+		},
 
 		sort_rows = {
 			'description': 'The number of sorted rows',
 			'value_type': 'float',
 			'units': 'rows',
-		}, 
+		},
 
 		sort_scan = {
 			'description': 'The number of sorts that were done by scanning the table',
 			'value_type': 'float',
 			'units': 'sorts',
-		}, 
+		},
 
 		table_locks_immediate = {
 			'description': 'The number of times that a request for a table lock could be granted immediately',
 			'value_type': 'float',
 			'units': 'count',
-		}, 
+		},
 
 		# If this is high and you have performance problems, you should first optimize your queries, and then either split your table or tables or use replication.
 		table_locks_waited = {
 			'description': 'The number of times that a request for a table lock could not be granted immediately and a wait was needed',
 			'value_type': 'float',
 			'units': 'count',
-		}, 
+		},
 
 		threads_cached = {
 			'description': 'The number of threads in the thread cache',
 			'units': 'threads',
 			'slope': 'both',
-		}, 
+		},
 
 		threads_connected = {
 			'description': 'The number of currently open connections',
 			'units': 'threads',
 			'slope': 'both',
-		}, 
+		},
 
 		#TODO in graphs: The cache miss rate can be calculated as Threads_created/Connections
 
-		# Threads_created is big, you may want to increase the thread_cache_size value. 
+		# Threads_created is big, you may want to increase the thread_cache_size value.
 		threads_created = {
 			'description': 'The number of threads created to handle connections',
 			'value_type': 'float',
 			'units': 'threads',
-		}, 
+		},
 
 		threads_running = {
 			'description': 'The number of threads that are not sleeping',
 			'units': 'threads',
 			'slope': 'both',
-		}, 
+		},
 
 		uptime = {
 			'description': 'The number of seconds that the server has been up',
 			'units': 'secs',
 			'slope': 'both',
-		}, 
+		},
 
 		version = {
 			'description': "Infobright uses MySQL Version",
@@ -757,28 +759,28 @@ def metric_init(params):
 			'slope': 'zero',
 		},
  	)
- 	
+
  	brighthouse_stats_descriptions = dict(
  		bh_gdc_read_wait_in_progress = {
  			'description': "The number of current read waits in Brighthouse tables.",
  			'slope': 'zero',
  		},
- 
+
 		bh_mm_alloc_size = {
 			'description': "The Brighthouse memory allocation size.",
 			'slope': 'zero',
 		},
-		
+
 		bh_mm_alloc_temp_size = {
 			'description': "Brighthouse memory allocation temp size.",
 			'slope': 'zero',
 		},
-		
+
 		bh_mm_free_pack_size = {
 			'description': "Brighthouse memory free pack size.",
 			'slope': 'zero',
 		},
-		
+
 		bh_mm_scale = {
 			'description': "Brighthouse memory scale.",
 			'slope': 'zero',
@@ -972,7 +974,6 @@ def metric_init(params):
 		}
 	)
 
-
 	if REPORT_MASTER:
 		master_stats_descriptions = dict(
 			binlog_count = {
@@ -1035,7 +1036,7 @@ def metric_init(params):
 				'slope': 'both',
 			},
 		)
-		
+
 	update_stats(REPORT_BRIGHTHOUSE, REPORT_BRIGHTHOUSE_ENGINE, REPORT_MASTER, REPORT_SLAVE)
 
 	time.sleep(MAX_UPDATE_TIME)
@@ -1071,6 +1072,7 @@ def metric_init(params):
 
 	#logging.debug(str(descriptors))
 	return descriptors
+
 
 def metric_cleanup():
 	logging.shutdown()
@@ -1124,4 +1126,3 @@ if __name__ == '__main__':
 			cmd = "%s --conf=%s --value='%s' --units='%s' --type='%s' --name='%s' --slope='%s'" % \
 				(options.gmetric_bin, options.gmond_conf, v, d['units'], value_type, d['name'], d['slope'])
 			os.system(cmd)
-

--- a/ipmi/python_modules/ipmi.py
+++ b/ipmi/python_modules/ipmi.py
@@ -12,7 +12,8 @@ METRICS = {
 
 METRICS_CACHE_MAX = 5
 
-stats_pos = {} 
+stats_pos = {}
+
 
 def get_metrics():
     """Return all metrics"""
@@ -24,7 +25,7 @@ def get_metrics():
 	new_metrics = {}
 	units = {}
 
-	command = [ params['timeout_bin'] , "3", params['ipmitool_bin'] , "-H", params['ipmi_ip'] , "-U" , params['username'] , '-P', params['password'] , 'sensor']	
+	command = [ params['timeout_bin'] , "3", params['ipmitool_bin'] , "-H", params['ipmi_ip'] , "-U" , params['username'] , '-P', params['password'] , 'sensor']
 
         p = subprocess.Popen(command,
                              stdout=subprocess.PIPE).communicate()[0][:-1]
@@ -47,12 +48,12 @@ def get_metrics():
 
                 new_metrics[metric_name] = metric_value
                 units[metric_name] = data[2].strip().replace("degrees C", "C")
-		
+
             except ValueError:
                 continue
             except IndexError:
                 continue
-		
+
 	METRICS = {
             'time': time.time(),
             'data': new_metrics,
@@ -70,7 +71,7 @@ def get_value(name):
 	metrics = get_metrics()[0]
 
 	prefix_length = len(params['metric_prefix']) + 1
-	name = name[prefix_length:] # remove prefix from name
+	name = name[prefix_length:]  # remove prefix from name
 
 	result = metrics['data'][name]
 
@@ -79,11 +80,13 @@ def get_value(name):
 
     return result
 
+
 def create_desc(skel, prop):
     d = skel.copy()
     for k,v in prop.iteritems():
         d[k] = v
     return d
+
 
 def metric_init(params):
     global descriptors, metric_map, Desc_Skel
@@ -97,13 +100,13 @@ def metric_init(params):
         'value_type'  : 'float',
         'format'      : '%.5f',
         'units'       : 'count/s',
-        'slope'       : 'both', # zero|positive|negative|both
+        'slope'       : 'both',  # zero|positive|negative|both
         'description' : 'XXX',
         'groups'      : 'XXX',
         }
 
     metrics = get_metrics()[0]
-    
+
     for item in metrics['data']:
 	descriptors.append(create_desc(Desc_Skel, {
 		"name"       	: params['metric_prefix'] + "_" + item,
@@ -111,8 +114,8 @@ def metric_init(params):
 		'units'		: metrics['units'][item]
 		}))
 
-
     return descriptors
+
 
 def metric_cleanup():
     '''Clean up the metric module.'''
@@ -120,7 +123,7 @@ def metric_cleanup():
 
 #This code is for debugging and unit testing
 if __name__ == '__main__':
-    
+
     params = {
         "metric_prefix" : "ipmi",
 	"ipmi_ip" : "10.1.2.3",

--- a/jenkins/python_modules/jenkins.py
+++ b/jenkins/python_modules/jenkins.py
@@ -16,6 +16,7 @@ logging.basicConfig(level=logging.ERROR)
 
 _Worker_Thread = None
 
+
 class UpdateJenkinsThread(threading.Thread):
 
   def __init__(self, params):
@@ -138,6 +139,7 @@ class UpdateJenkinsThread(threading.Thread):
       logging.warning('failed to fetch ' + name)
       return 0
 
+
 def metric_init(params):
   logging.debug('init: ' + str(params))
   global _Worker_Thread
@@ -201,13 +203,16 @@ def metric_init(params):
     descriptors.append(d)
   return descriptors
 
+
 def metric_of(name):
   global _Worker_Thread
   return _Worker_Thread.metric_of(name)
 
+
 def setting_of(name):
   global _Worker_Thread
   return _Worker_Thread.setting_of(name)
+
 
 def metric_cleanup():
   global _Worker_Thread

--- a/jmxsh/python_modules/jmxsh.py
+++ b/jmxsh/python_modules/jmxsh.py
@@ -58,6 +58,7 @@ METRIC_GROUP = 'jmx'
 MAX_UPDATE_TIME = 15
 JMXSH = '/usr/share/java/jmxsh.jar'
 
+
 def get_numeric(val):
 	'''Try to return the numeric value of the string'''
 
@@ -67,6 +68,7 @@ def get_numeric(val):
 		pass
 
 	return val
+
 
 def get_gmond_format(val):
 	'''Return the formatting and value_type values to use with gmond'''
@@ -81,10 +83,11 @@ def get_gmond_format(val):
 	else:
 		return ('string', '%u')
 
+
 def update_stats():
 	logging.debug('updating stats')
 	global last_update, stats, last_val
-	
+
 	cur_time = time.time()
 
 	if cur_time - last_update < MAX_UPDATE_TIME:
@@ -98,7 +101,7 @@ def update_stats():
 		sh += 'puts "' + name + ': [jmx_get -m ' + mbean + ']"\n'
 
 	#logging.debug(sh)
-	
+
 	try:
 		# run jmxsh.jar with the temp file as a script
 		cmd = "java -jar " + JMXSH + " -q"
@@ -179,6 +182,7 @@ def update_stats():
 	last_update = cur_time
 	return True
 
+
 def get_stat(name):
 	logging.debug('getting stat: ' + name)
 
@@ -199,6 +203,7 @@ def get_stat(name):
 	else:
 		return 0
 
+
 def metric_init(params):
 	global descriptors
 	global METRICS,HOST,PORT,NAME,METRIC_GROUP
@@ -210,7 +215,7 @@ def metric_init(params):
 		PORT = params.pop('port')
 		NAME = params.pop('name')
 		METRIC_GROUP = params.pop('metric_group')
-		
+
 	except:
 		logging.warning('Incorrect parameters')
 
@@ -264,6 +269,7 @@ def metric_init(params):
 
 	return descriptors
 
+
 def metric_cleanup():
 	logging.shutdown()
 	# pass
@@ -292,7 +298,7 @@ if __name__ == '__main__':
 	for name in _param:
 		params[name] = _val[i]
 		i += 1
-	
+
 	metric_init(params)
 
 	if options.test:
@@ -315,4 +321,3 @@ if __name__ == '__main__':
 			cmd = "%s --conf=%s --value='%s' --units='%s' --type='%s' --name='%s' --slope='%s'" % \
 				(options.gmetric_bin, options.gmond_conf, v, d['units'], value_type, d['name'], d['slope'])
 			os.system(cmd)
-

--- a/kestrel/python_modules/kstats.py
+++ b/kestrel/python_modules/kstats.py
@@ -21,6 +21,7 @@ METRICS = {
 }
 METRICS_CACHE_MAX = 5
 
+
 def get_metrics():
     global METRICS
 
@@ -68,11 +69,13 @@ def get_metrics():
 
     return METRICS
 
+
 def metric_of(name):
     curr_metrics = get_metrics()
     if name in curr_metrics['data']:
         return curr_metrics['data'][name]
     return 0
+
 
 def metric_init(lparams):
     global descriptors, PARAMS
@@ -88,7 +91,7 @@ def metric_init(lparams):
         'value_type': 'uint',
         'format': '%u',
         'units': 'XXX',
-        'slope': 'both', # zero|positive|negative|both
+        'slope': 'both',  # zero|positive|negative|both
         'description': 'XXX',
         'groups': PARAMS['type'],
     }
@@ -243,6 +246,7 @@ def metric_init(lparams):
             descriptors.append(_qd)
 
     return descriptors
+
 
 def metric_cleanup():
     pass

--- a/kumofs/python_modules/kumofs.py
+++ b/kumofs/python_modules/kumofs.py
@@ -12,12 +12,14 @@ import re
 descriptors = list()
 Desc_Skel   = {}
 _Worker_Thread = None
-_Lock = threading.Lock() # synchronization lock
+_Lock = threading.Lock()  # synchronization lock
 Debug = False
+
 
 def dprint(f, *v):
     if Debug:
         print >>sys.stderr, "DEBUG: "+f % v
+
 
 class UpdateMetricThread(threading.Thread):
 
@@ -74,6 +76,7 @@ class UpdateMetricThread(threading.Thread):
             _Lock.release()
         return val
 
+
 def metric_init(params):
     global descriptors, Desc_Skel, _Worker_Thread, Debug
 
@@ -88,7 +91,7 @@ def metric_init(params):
         'value_type'  : 'uint',
         'format'      : '%d',
         'units'       : 'XXX',
-        'slope'       : 'XXX', # zero|positive|negative|both
+        'slope'       : 'XXX',  # zero|positive|negative|both
         'description' : 'XXX',
         'groups'      : 'kumofs',
         }
@@ -133,14 +136,17 @@ def metric_init(params):
 
     return descriptors
 
+
 def create_desc(skel, prop):
     d = skel.copy()
     for k,v in prop.iteritems():
         d[k] = v
     return d
 
+
 def metric_of(name):
     return _Worker_Thread.metric_of(name)
+
 
 def metric_cleanup():
     _Worker_Thread.shutdown()

--- a/memcached/python_modules/memcached.py
+++ b/memcached/python_modules/memcached.py
@@ -12,12 +12,14 @@ import select
 descriptors = list()
 Desc_Skel   = {}
 _Worker_Thread = None
-_Lock = threading.Lock() # synchronization lock
+_Lock = threading.Lock()  # synchronization lock
 Debug = False
+
 
 def dprint(f, *v):
     if Debug:
         print >>sys.stderr, "DEBUG: "+f % v
+
 
 def floatable(str):
     try:
@@ -25,6 +27,7 @@ def floatable(str):
         return True
     except:
         return False
+
 
 class UpdateMetricThread(threading.Thread):
 
@@ -117,6 +120,7 @@ class UpdateMetricThread(threading.Thread):
             _Lock.release()
         return val
 
+
 def metric_init(params):
     global descriptors, Desc_Skel, _Worker_Thread, Debug
 
@@ -140,7 +144,7 @@ def metric_init(params):
         'value_type'  : 'float',
         'format'      : '%.0f',
         'units'       : 'XXX',
-        'slope'       : 'XXX', # zero|positive|negative|both
+        'slope'       : 'XXX',  # zero|positive|negative|both
         'description' : 'XXX',
         'groups'      : params["type"],
         }
@@ -301,8 +305,8 @@ def metric_init(params):
                     "description": "Number of items that have been deleted and not found",
                     }))
 
-
     return descriptors
+
 
 def create_desc(skel, prop):
     d = skel.copy()
@@ -310,8 +314,10 @@ def create_desc(skel, prop):
         d[k] = v
     return d
 
+
 def metric_of(name):
     return _Worker_Thread.metric_of(name)
+
 
 def metric_cleanup():
     _Worker_Thread.shutdown()

--- a/memcached_maxage/python_modules/every.py
+++ b/memcached_maxage/python_modules/every.py
@@ -52,6 +52,7 @@ def every(*args, **kwargs):
     the return value is discarded.
     """
     interval = total_seconds(timedelta(*args, **kwargs))
+
     def decorator(func):
         def poll():
             func()

--- a/mongodb/python_modules/mongodb.py
+++ b/mongodb/python_modules/mongodb.py
@@ -72,8 +72,8 @@ def get_metrics():
             io = os.popen(PARAMS[status_type])
 
             # clean up
-            metrics_str = ''.join(io.readlines()).strip() # convert to string
-            metrics_str = re.sub('\w+\((.*)\)', r"\1", metrics_str) # remove functions
+            metrics_str = ''.join(io.readlines()).strip()  # convert to string
+            metrics_str = re.sub('\w+\((.*)\)', r"\1", metrics_str)  # remove functions
 
             # convert to flattened dict
             try:
@@ -101,7 +101,7 @@ def get_value(name):
     metrics = get_metrics()[0]
 
     # get value
-    name = name[len(NAME_PREFIX):] # remove prefix from name
+    name = name[len(NAME_PREFIX):]  # remove prefix from name
     try:
         result = metrics['data'][name]
     except StandardError:
@@ -117,7 +117,7 @@ def get_rate(name):
     [curr_metrics, last_metrics] = get_metrics()
 
     # get rate
-    name = name[len(NAME_PREFIX):] # remove prefix from name
+    name = name[len(NAME_PREFIX):]  # remove prefix from name
 
     try:
         rate = float(curr_metrics['data'][name] - last_metrics['data'][name]) / \

--- a/multi_nginx_status/python_modules/multi_nginx_status.py
+++ b/multi_nginx_status/python_modules/multi_nginx_status.py
@@ -22,6 +22,7 @@ NIMETRICS = {
 LAST_NIMETRICS = {}
 NIMETRICS_CACHE_MAX = 10
 
+
 # status_request() makes the http request to the nginx status pages
 def status_request(srvname, port):
     url = 'http://' + srvname + ':' + port + '/nginx_status'
@@ -49,6 +50,7 @@ def status_request(srvname, port):
 
     return result
 
+
 # get_metrics() is the callback metric handler, is called repeatedly by gmond
 def get_metrics(name):
     global NIMETRICS,LAST_NIMETRICS
@@ -59,7 +61,7 @@ def get_metrics(name):
             srvname,port = NIPARAMS[para].split(':')
             newmetrics = status_request(srvname,port)
             metrics = dict(newmetrics, **metrics)
-                        
+
         LAST_NIMETRICS = dict(NIMETRICS)
         NIMETRICS = {
             'time': time.time(),
@@ -78,13 +80,15 @@ def get_metrics(name):
             return delta
 
     return NIMETRICS['data'][name]
-        
+
+
 # create_desc() builds the descriptors from passed skeleton and additional properties
 def create_desc(skel, prop):
     d = skel.copy()
     for k,v in prop.iteritems():
         d[k] = v
     return d
+
 
 # called by metric_init() to setup the metrics
 def define_metrics(Desc_Skel, srvname, port):
@@ -135,6 +139,8 @@ def define_metrics(Desc_Skel, srvname, port):
                 }))
 
     return descriptors
+
+
 # Called once by gmond to setup the metrics.
 def metric_init(params):
     global descriptors, Desc_Skel
@@ -156,7 +162,7 @@ def metric_init(params):
         'description' : 'XXX',
         'groups'      : 'nginx',
         #'spoof_host'  : spoof_string
-        }  
+        }
 
     for para in params.keys():
         if para.startswith('server_'):

--- a/mysql/python_modules/mysql.py
+++ b/mysql/python_modules/mysql.py
@@ -11,7 +11,8 @@ import MySQLdb
 descriptors = list()
 Desc_Skel   = {}
 _Worker_Thread = None
-_Lock = threading.Lock() # synchronization lock
+_Lock = threading.Lock()  # synchronization lock
+
 
 class UpdateMetricThread(threading.Thread):
 
@@ -71,7 +72,7 @@ class UpdateMetricThread(threading.Thread):
                     break
                 my_status[ row[0][0].lower() ] = int(row[0][1]) if row[0][1].isdigit() else row[0][1]
 
-            conn.query("show table status from oriri like 'health'") # fixme
+            conn.query("show table status from oriri like 'health'")  # fixme
             r = conn.store_result()
             row = r.fetch_row(1,1)
             my_status["innodb_free"] = float(row[0]["Data_free"])
@@ -131,6 +132,7 @@ class UpdateMetricThread(threading.Thread):
             _Lock.release()
         return val
 
+
 def metric_init(params):
     global descriptors, Desc_Skel, _Worker_Thread
 
@@ -144,7 +146,7 @@ def metric_init(params):
         "time_max"    : 60,
         "value_type"  : "uint",
         "units"       : "XXX",
-        "slope"       : "XXX", # zero|positive|negative|both
+        "slope"       : "XXX",  # zero|positive|negative|both
         "format"      : "%d",
         "description" : "XXX",
         "groups"      : "mysql",
@@ -276,8 +278,8 @@ def metric_init(params):
                 "name"       : "my_tmp_table_on_memory",
                 "description": "tmp table on memory ratio", }));
 
-
     return descriptors
+
 
 def create_desc(skel, prop):
     d = skel.copy()
@@ -285,8 +287,10 @@ def create_desc(skel, prop):
         d[k] = v
     return d
 
+
 def metric_of(name):
     return _Worker_Thread.metric_of(name)
+
 
 def metric_cleanup():
     _Worker_Thread.shutdown()

--- a/mysqld/python_modules/DBUtil.py
+++ b/mysqld/python_modules/DBUtil.py
@@ -29,42 +29,52 @@ pure python collections.defaultdict substitute
 try:
     from collections import defaultdict
 except:
+
     class defaultdict(dict):
+
         def __init__(self, default_factory=None, *a, **kw):
             if (default_factory is not None and
                 not hasattr(default_factory, '__call__')):
                 raise TypeError('first argument must be callable')
             dict.__init__(self, *a, **kw)
             self.default_factory = default_factory
+
         def __getitem__(self, key):
             try:
                 return dict.__getitem__(self, key)
             except KeyError:
                 return self.__missing__(key)
+
         def __missing__(self, key):
             if self.default_factory is None:
                 raise KeyError(key)
             self[key] = value = self.default_factory()
             return value
+
         def __reduce__(self):
             if self.default_factory is None:
                 args = tuple()
             else:
                 args = self.default_factory,
             return type(self), args, None, None, self.items()
+
         def copy(self):
             return self.__copy__()
+
         def __copy__(self):
             return type(self)(self.default_factory, self)
+
         def __deepcopy__(self, memo):
             import copy
             return type(self)(self.default_factory,
                               copy.deepcopy(self.items()))
+
         def __repr__(self):
             return 'defaultdict(%s, %s)' % (self.default_factory,
                                             dict.__repr__(self))
 
 import MySQLdb
+
 
 def longish(x):
 	if len(x):
@@ -74,7 +84,8 @@ def longish(x):
 			return longish(x[:-1])
 	else:
 		raise ValueError
-		
+
+
 def hexlongish(x):
 	if len(x):
 		try:
@@ -84,6 +95,7 @@ def hexlongish(x):
 	else:
 		raise ValueError
 
+
 def parse_innodb_status(innodb_status_raw, innodb_version="1.0"):
 	def sumof(status):
 		def new(*idxs):
@@ -92,7 +104,7 @@ def parse_innodb_status(innodb_status_raw, innodb_version="1.0"):
 
 	innodb_status = defaultdict(int)
 	innodb_status['active_transactions']
-	
+
 	for line in innodb_status_raw:
 		istatus = line.split()
 
@@ -190,13 +202,13 @@ def parse_innodb_status(innodb_status_raw, innodb_version="1.0"):
 		elif "pending log writes" in line:
 			innodb_status['pending_log_writes'] = longish(istatus[0])
 			innodb_status['pending_chkp_writes'] = longish(istatus[4])
-		
+
 		elif "Log sequence number" in line:
 			if innodb_version >= 5.5:
 				innodb_status['log_bytes_written'] = longish(istatus[3])
 			else:
 				innodb_status['log_bytes_written'] = isum(3,4)
-		
+
 		elif "Log flushed up to" in line:
 			if innodb_version >= 5.5:
 				innodb_status['log_bytes_flushed'] = longish(istatus[4])
@@ -206,16 +218,16 @@ def parse_innodb_status(innodb_status_raw, innodb_version="1.0"):
 		# BUFFER POOL AND MEMORY
 		elif "Buffer pool size" in line:
 			innodb_status['buffer_pool_pages_total'] = longish(istatus[3])
-		
+
 		elif "Free buffers" in line:
 			innodb_status['buffer_pool_pages_free'] = longish(istatus[2])
-		
+
 		elif "Database pages" in line:
 			innodb_status['buffer_pool_pages_data'] = longish(istatus[2])
-		
+
 		elif "Modified db pages" in line:
 			innodb_status['buffer_pool_pages_dirty'] = longish(istatus[3])
-		
+
 		elif "Pages read" in line and "ahead" not in line:
 				innodb_status['pages_read'] = longish(istatus[2])
 				innodb_status['pages_created'] = longish(istatus[4])
@@ -227,7 +239,7 @@ def parse_innodb_status(innodb_status_raw, innodb_version="1.0"):
 			innodb_status['rows_updated'] = longish(istatus[6])
 			innodb_status['rows_deleted'] = longish(istatus[8])
 			innodb_status['rows_read'] = longish(istatus[10])
-		
+
 		elif "queries inside InnoDB" in line:
 			innodb_status['queries_inside'] = longish(istatus[0])
 			innodb_status['queries_queued'] = longish(istatus[4])
@@ -237,7 +249,7 @@ def parse_innodb_status(innodb_status_raw, innodb_version="1.0"):
 	innodb_status['log_bytes_unflushed'] = innodb_status['log_bytes_written'] - innodb_status['log_bytes_flushed']
 
 	return innodb_status
-	
+
 if __name__ == '__main__':
 	from optparse import OptionParser
 
@@ -258,4 +270,3 @@ if __name__ == '__main__':
 		conn.close()
 	except MySQLdb.OperationalError, (errno, errmsg):
 		raise
-

--- a/mysqld/python_modules/mysql.py
+++ b/mysqld/python_modules/mysql.py
@@ -65,6 +65,7 @@ REPORT_SLAVE  = True
 
 MAX_UPDATE_TIME = 15
 
+
 def update_stats(get_innodb=True, get_master=True, get_slave=True):
 	"""
 
@@ -115,14 +116,14 @@ def update_stats(get_innodb=True, get_master=True, get_slave=True):
 		for (k,v) in cursor:
 			global_status[k.lower()] = v
 		cursor.close()
-		
+
 		cursor = conn.cursor(MySQLdb.cursors.Cursor)
 		cursor.execute("SELECT PLUGIN_STATUS, PLUGIN_VERSION FROM `information_schema`.Plugins WHERE PLUGIN_NAME LIKE '%innodb%' AND PLUGIN_TYPE LIKE 'STORAGE ENGINE';")
-		
+
 		have_innodb = False
 		innodb_version = 1.0
 		row = cursor.fetchone()
-		
+
 		if row[0] == "ACTIVE":
 			have_innodb = True
 			innodb_version = row[1]
@@ -328,9 +329,9 @@ def update_stats(get_innodb=True, get_master=True, get_slave=True):
 		mysql_stats['slave_relay_log_pos'] = slave_status['relay_log_pos']
 		mysql_stats['slave_relay_log_space'] = slave_status['relay_log_space']
 
-
 	logging.debug('success updating stats')
 	logging.debug('mysql_stats: ' + str(mysql_stats))
+
 
 def get_stat(name):
 	logging.info("getting stat: %s" % name)
@@ -357,6 +358,7 @@ def get_stat(name):
 			return 0
 	else:
 		return 0
+
 
 def metric_init(params):
 	global descriptors
@@ -396,121 +398,121 @@ def metric_init(params):
 			'description': 'The number of connections that were aborted because the client died without closing the connection properly',
 			'value_type': 'float',
 			'units': 'clients',
-		}, 
+		},
 
 		aborted_connects = {
 			'description': 'The number of failed attempts to connect to the MySQL server',
 			'value_type': 'float',
 			'units': 'conns',
-		}, 
+		},
 
 		binlog_cache_disk_use = {
 			'description': 'The number of transactions that used the temporary binary log cache but that exceeded the value of binlog_cache_size and used a temporary file to store statements from the transaction',
 			'value_type': 'float',
 			'units': 'txns',
-		}, 
+		},
 
 		binlog_cache_use = {
 			'description': ' The number of transactions that used the temporary binary log cache',
 			'value_type': 'float',
 			'units': 'txns',
-		}, 
+		},
 
 		bytes_received = {
 			'description': 'The number of bytes received from all clients',
 			'value_type': 'float',
 			'units': 'bytes',
-		}, 
+		},
 
 		bytes_sent = {
 			'description': ' The number of bytes sent to all clients',
 			'value_type': 'float',
 			'units': 'bytes',
-		}, 
+		},
 
 		com_delete = {
 			'description': 'The number of DELETE statements',
 			'value_type': 'float',
 			'units': 'stmts',
-		}, 
+		},
 
 		com_delete_multi = {
 			'description': 'The number of multi-table DELETE statements',
 			'value_type': 'float',
 			'units': 'stmts',
-		}, 
+		},
 
 		com_insert = {
 			'description': 'The number of INSERT statements',
 			'value_type': 'float',
 			'units': 'stmts',
-		}, 
+		},
 
 		com_insert_select = {
 			'description': 'The number of INSERT ... SELECT statements',
 			'value_type': 'float',
 			'units': 'stmts',
-		}, 
+		},
 
 		com_load = {
 			'description': 'The number of LOAD statements',
 			'value_type': 'float',
 			'units': 'stmts',
-		}, 
+		},
 
 		com_replace = {
 			'description': 'The number of REPLACE statements',
 			'value_type': 'float',
 			'units': 'stmts',
-		}, 
+		},
 
 		com_replace_select = {
 			'description': 'The number of REPLACE ... SELECT statements',
 			'value_type': 'float',
 			'units': 'stmts',
-		}, 
+		},
 
 		com_select = {
 			'description': 'The number of SELECT statements',
 			'value_type': 'float',
 			'units': 'stmts',
-		}, 
+		},
 
 		com_update = {
 			'description': 'The number of UPDATE statements',
 			'value_type': 'float',
 			'units': 'stmts',
-		}, 
+		},
 
 		com_update_multi = {
 			'description': 'The number of multi-table UPDATE statements',
 			'value_type': 'float',
 			'units': 'stmts',
-		}, 
+		},
 
 		connections = {
 			'description': 'The number of connection attempts (successful or not) to the MySQL server',
 			'value_type': 'float',
 			'units': 'conns',
-		}, 
+		},
 
 		created_tmp_disk_tables = {
 			'description': 'The number of temporary tables on disk created automatically by the server while executing statements',
 			'value_type': 'float',
 			'units': 'tables',
-		}, 
+		},
 
 		created_tmp_files = {
 			'description': 'The number of temporary files mysqld has created',
 			'value_type': 'float',
 			'units': 'files',
-		}, 
+		},
 
 		created_tmp_tables = {
 			'description': 'The number of in-memory temporary tables created automatically by the server while executing statement',
 			'value_type': 'float',
 			'units': 'tables',
-		}, 
+		},
 
 		#TODO in graphs: key_read_cache_miss_rate = key_reads / key_read_requests
 
@@ -518,224 +520,224 @@ def metric_init(params):
 			'description': 'The number of requests to read a key block from the cache',
 			'value_type': 'float',
 			'units': 'reqs',
-		}, 
+		},
 
 		key_reads = {
 			'description': 'The number of physical reads of a key block from disk',
 			'value_type': 'float',
 			'units': 'reads',
-		}, 
+		},
 
 		key_write_requests = {
 			'description': 'The number of requests to write a key block to the cache',
 			'value_type': 'float',
 			'units': 'reqs',
-		}, 
+		},
 
 		key_writes = {
 			'description': 'The number of physical writes of a key block to disk',
 			'value_type': 'float',
 			'units': 'writes',
-		}, 
+		},
 
 		max_used_connections = {
 			'description': 'The maximum number of connections that have been in use simultaneously since the server started',
 			'units': 'conns',
 			'slope': 'both',
-		}, 
+		},
 
 		open_files = {
 			'description': 'The number of files that are open',
 			'units': 'files',
 			'slope': 'both',
-		}, 
+		},
 
 		open_tables = {
 			'description': 'The number of tables that are open',
 			'units': 'tables',
 			'slope': 'both',
-		}, 
+		},
 
-		# If Opened_tables is big, your table_cache value is probably too small. 
+		# If Opened_tables is big, your table_cache value is probably too small.
 		opened_tables = {
 			'description': 'The number of tables that have been opened',
 			'value_type': 'float',
 			'units': 'tables',
-		}, 
+		},
 
 		qcache_free_blocks = {
 			'description': 'The number of free memory blocks in the query cache',
 			'units': 'blocks',
 			'slope': 'both',
-		}, 
+		},
 
 		qcache_free_memory = {
 			'description': 'The amount of free memory for the query cache',
 			'units': 'bytes',
 			'slope': 'both',
-		}, 
+		},
 
 		qcache_hits = {
 			'description': 'The number of query cache hits',
 			'value_type': 'float',
 			'units': 'hits',
-		}, 
+		},
 
 		qcache_inserts = {
 			'description': 'The number of queries added to the query cache',
 			'value_type': 'float',
 			'units': 'queries',
-		}, 
+		},
 
 		qcache_lowmem_prunes = {
 			'description': 'The number of queries that were deleted from the query cache because of low memory',
 			'value_type': 'float',
 			'units': 'queries',
-		}, 
+		},
 
 		qcache_not_cached = {
 			'description': 'The number of non-cached queries (not cacheable, or not cached due to the query_cache_type setting)',
 			'value_type': 'float',
 			'units': 'queries',
-		}, 
+		},
 
 		qcache_queries_in_cache = {
 			'description': 'The number of queries registered in the query cache',
 			'value_type': 'float',
 			'units': 'queries',
-		}, 
+		},
 
 		qcache_total_blocks = {
 			'description': 'The total number of blocks in the query cache',
 			'units': 'blocks',
-		}, 
+		},
 
 		questions = {
 			'description': 'The number of statements that clients have sent to the server',
 			'value_type': 'float',
 			'units': 'stmts',
-		}, 
+		},
 
 		# If this value is not 0, you should carefully check the indexes of your tables.
 		select_full_join = {
 			'description': 'The number of joins that perform table scans because they do not use indexes',
 			'value_type': 'float',
 			'units': 'joins',
-		}, 
+		},
 
 		select_full_range_join = {
 			'description': 'The number of joins that used a range search on a reference table',
 			'value_type': 'float',
 			'units': 'joins',
-		}, 
+		},
 
 		select_range = {
 			'description': 'The number of joins that used ranges on the first table',
 			'value_type': 'float',
 			'units': 'joins',
-		}, 
+		},
 
 		# If this is not 0, you should carefully check the indexes of your tables.
 		select_range_check = {
 			'description': 'The number of joins without keys that check for key usage after each row',
 			'value_type': 'float',
 			'units': 'joins',
-		}, 
+		},
 
 		select_scan = {
 			'description': 'The number of joins that did a full scan of the first table',
 			'value_type': 'float',
 			'units': 'joins',
-		}, 
+		},
 
 		slave_open_temp_tables = {
 			'description': 'The number of temporary tables that the slave SQL thread currently has open',
 			'value_type': 'float',
 			'units': 'tables',
 			'slope': 'both',
-		}, 
+		},
 
 		slave_retried_transactions = {
 			'description': 'The total number of times since startup that the replication slave SQL thread has retried transactions',
 			'value_type': 'float',
 			'units': 'count',
-		}, 
+		},
 
 		slow_launch_threads = {
 			'description': 'The number of threads that have taken more than slow_launch_time seconds to create',
 			'value_type': 'float',
 			'units': 'threads',
-		}, 
+		},
 
 		slow_queries = {
 			'description': 'The number of queries that have taken more than long_query_time seconds',
 			'value_type': 'float',
 			'units': 'queries',
-		}, 
+		},
 
 		sort_range = {
 			'description': 'The number of sorts that were done using ranges',
 			'value_type': 'float',
 			'units': 'sorts',
-		}, 
+		},
 
 		sort_rows = {
 			'description': 'The number of sorted rows',
 			'value_type': 'float',
 			'units': 'rows',
-		}, 
+		},
 
 		sort_scan = {
 			'description': 'The number of sorts that were done by scanning the table',
 			'value_type': 'float',
 			'units': 'sorts',
-		}, 
+		},
 
 		table_locks_immediate = {
 			'description': 'The number of times that a request for a table lock could be granted immediately',
 			'value_type': 'float',
 			'units': 'count',
-		}, 
+		},
 
 		# If this is high and you have performance problems, you should first optimize your queries, and then either split your table or tables or use replication.
 		table_locks_waited = {
 			'description': 'The number of times that a request for a table lock could not be granted immediately and a wait was needed',
 			'value_type': 'float',
 			'units': 'count',
-		}, 
+		},
 
 		threads_cached = {
 			'description': 'The number of threads in the thread cache',
 			'units': 'threads',
 			'slope': 'both',
-		}, 
+		},
 
 		threads_connected = {
 			'description': 'The number of currently open connections',
 			'units': 'threads',
 			'slope': 'both',
-		}, 
+		},
 
 		#TODO in graphs: The cache miss rate can be calculated as Threads_created/Connections
 
-		# Threads_created is big, you may want to increase the thread_cache_size value. 
+		# Threads_created is big, you may want to increase the thread_cache_size value.
 		threads_created = {
 			'description': 'The number of threads created to handle connections',
 			'value_type': 'float',
 			'units': 'threads',
-		}, 
+		},
 
 		threads_running = {
 			'description': 'The number of threads that are not sleeping',
 			'units': 'threads',
 			'slope': 'both',
-		}, 
+		},
 
 		uptime = {
 			'description': 'The number of seconds that the server has been up',
 			'units': 'secs',
 			'slope': 'both',
-		}, 
+		},
 
 		version = {
 			'description': "MySQL Version",
@@ -1117,6 +1119,7 @@ def metric_init(params):
 	#logging.debug(str(descriptors))
 	return descriptors
 
+
 def metric_cleanup():
 	logging.shutdown()
 	# pass
@@ -1167,4 +1170,3 @@ if __name__ == '__main__':
 			cmd = "%s --conf=%s --value='%s' --units='%s' --type='%s' --name='%s' --slope='%s'" % \
 				(options.gmetric_bin, options.gmond_conf, v, d['units'], value_type, d['name'], d['slope'])
 			os.system(cmd)
-

--- a/netapp_api/python_modules/netapp_api.py
+++ b/netapp_api/python_modules/netapp_api.py
@@ -24,12 +24,13 @@ LAST_FASMETRICS = dict(FASMETRICS)
 #This is the minimum interval between querying the RPA for metrics
 FASMETRICS_CACHE_MAX = 10
 
+
 def get_metrics(name):
     global FASMETRICS, LAST_FASMETRICS, FASMETRICS_CACHE_MAX, params
     max_records = 10
     metrics = {}
     if (time.time() - FASMETRICS['time']) > FASMETRICS_CACHE_MAX:
-        
+
         for filer in filerdict.keys():
             s = NaServer(filerdict[filer]['ipaddr'], 1, 3)
             out = s.set_transport_type('HTTPS')
@@ -37,7 +38,7 @@ def get_metrics(name):
                 r = out.results_reason()
                 print ("Connection to filer failed: " + r + "\n")
                 sys.exit(2)
-            
+
             out = s.set_style('LOGIN')
             if (out and out.results_errno() != 0) :
                 r = out.results_reason()
@@ -66,7 +67,7 @@ def get_metrics(name):
             if(out.results_status() == "failed"):
                 print(out.results_reason() + "\n")
                 sys.exit(2)
-    
+
             iter_tag = out.child_get_string("tag")
             num_records = 1
 
@@ -83,9 +84,9 @@ def get_metrics(name):
                     sys.exit(2)
 
                 num_records = out.child_get_int("records")
-	
+
                 if(num_records > 0) :
-                    instances_list = out.child_get("instances")            
+                    instances_list = out.child_get("instances")
                     instances = instances_list.children_get()
 
                     for inst in instances:
@@ -94,9 +95,9 @@ def get_metrics(name):
                         counters = counters_list.children_get()
 
                         for counter in counters:
-                            counter_name = unicodedata.normalize('NFKD',counter.child_get_string("name")).encode('ascii','ignore')         
+                            counter_name = unicodedata.normalize('NFKD',counter.child_get_string("name")).encode('ascii','ignore')
                             counter_value = counter.child_get_string("value")
-                            counter_unit = counter.child_get_string("unit")           
+                            counter_unit = counter.child_get_string("unit")
                             metrics[filername + '_vol_' + inst_name + '_' + counter_name] = float(counter_value)
         # update cache
         LAST_FASMETRICS = dict(FASMETRICS)
@@ -105,8 +106,7 @@ def get_metrics(name):
             'data': metrics
             }
 
-
-    else: 
+    else:
         metrics = FASMETRICS['data']
     #print name
     #calculate change in values and return
@@ -122,7 +122,7 @@ def get_metrics(name):
         return delta
 
     elif 'avg_latency' in name:
-        try: 
+        try:
             #T1 and T2
             #(T2_lat - T1_lat) / (T2_ops - T1_ops)
             #Find the metric name of the base counter
@@ -143,7 +143,7 @@ def get_metrics(name):
         return delta
 
     elif 'read_latency' in name:
-        try: 
+        try:
             read_ops_name = name.replace('read_latency', 'read_ops')
             return float((FASMETRICS['data'][name] - LAST_FASMETRICS['data'][name]) / (FASMETRICS['data'][read_ops_name] -LAST_FASMETRICS['data'][read_ops_name])) / 100
         except StandardError:
@@ -159,15 +159,13 @@ def get_metrics(name):
         return delta
 
     elif 'write_latency' in name:
-        try: 
+        try:
             write_ops_name = name.replace('write_latency', 'write_ops')
             return float((FASMETRICS['data'][name] - LAST_FASMETRICS['data'][name]) / (FASMETRICS['data'][write_ops_name] -LAST_FASMETRICS['data'][write_ops_name])) / 100
         except StandardError:
             return 0
-            
 
-    return 0    
-        
+    return 0
 
 
 def create_desc(skel, prop):
@@ -175,7 +173,8 @@ def create_desc(skel, prop):
     for k,v in prop.iteritems():
         d[k] = v
     return d
-    
+
+
 def define_metrics(Desc_Skel,params):
     max_records = 10
     for filer in params.keys():
@@ -185,7 +184,7 @@ def define_metrics(Desc_Skel,params):
             r = out.results_reason()
             print ("Connection to filer failed: " + r + "\n")
             sys.exit(2)
-            
+
         out = s.set_style('LOGIN')
         if (out and out.results_errno() != 0) :
             r = out.results_reason()
@@ -214,7 +213,7 @@ def define_metrics(Desc_Skel,params):
         if(out.results_status() == "failed"):
             print(out.results_reason() + "\n")
             sys.exit(2)
-    
+
         iter_tag = out.child_get_string("tag")
         num_records = 1
         filername = params[filer]['name']
@@ -230,9 +229,9 @@ def define_metrics(Desc_Skel,params):
                 sys.exit(2)
 
             num_records = out.child_get_int("records")
-	
+
             if(num_records > 0) :
-                instances_list = out.child_get("instances")            
+                instances_list = out.child_get("instances")
                 instances = instances_list.children_get()
 
                 for inst in instances:
@@ -293,8 +292,9 @@ def define_metrics(Desc_Skel,params):
                                         "spoof_host"  : params[filer]['ipaddr'] + ':' + params[filer]['name'],
                                         "groups"      : "latency"
                                         }))
-                        
+
     return descriptors
+
 
 def metric_init(params):
     global descriptors,filerdict
@@ -321,7 +321,7 @@ def metric_init(params):
         'description' : 'XXX',
         'groups'      : 'netiron',
         'spoof_host'  : 'XXX',
-        }  
+        }
 
     # Run define_metrics
     descriptors = define_metrics(Desc_Skel,params)
@@ -346,6 +346,6 @@ if __name__ == '__main__':
         for d in descriptors:
             v = d['call_back'](d['name'])
             #print v
-            print 'value for %s is %.2f' % (d['name'],  v)        
+            print 'value for %s is %.2f' % (d['name'],  v)
         print 'Sleeping 5 seconds'
         time.sleep(5)

--- a/network/conntrack/python_modules/conntrack.py
+++ b/network/conntrack/python_modules/conntrack.py
@@ -40,6 +40,7 @@ METRICS = {
 LAST_METRICS = copy.deepcopy(METRICS)
 METRICS_CACHE_MAX = 5
 
+
 def create_desc(skel, prop):
     d = skel.copy()
     for k,v in prop.iteritems():
@@ -75,12 +76,13 @@ def get_metrics():
 
     return [METRICS, LAST_METRICS]
 
+
 def get_value(name):
     """Return a value for the requested metric"""
 
     metrics = get_metrics()[0]
 
-    name = name[len(NAME_PREFIX):] # remove prefix from name
+    name = name[len(NAME_PREFIX):]  # remove prefix from name
     try:
         result = metrics['data'][name]
     except StandardError:
@@ -96,7 +98,7 @@ def get_delta(name):
     [curr_metrics, last_metrics] = get_metrics()
 
     # get delta
-    name = name[len(NAME_PREFIX):] # remove prefix from name
+    name = name[len(NAME_PREFIX):]  # remove prefix from name
     try:
         delta = float(curr_metrics['data'][name] - last_metrics['data'][name])/(curr_metrics['time'] - last_metrics['time'])
         if delta < 0:
@@ -138,7 +140,7 @@ def metric_init(lparams):
         'value_type'  : 'float',
         'format'      : '%f',
         'units'       : 'XXX',
-        'slope'       : 'both', # zero|positive|negative|both
+        'slope'       : 'both',  # zero|positive|negative|both
         'description' : 'XXX',
         'groups'      : 'conntrack',
         }
@@ -245,7 +247,7 @@ def metric_init(lparams):
                 "call_back"  : get_delta,
                 "units"      : "ops/s",
                 "description": "",
-                })) 
+                }))
 
     return descriptors
 

--- a/network/multi_interface/python_modules/multi_interface.py
+++ b/network/multi_interface/python_modules/multi_interface.py
@@ -32,16 +32,18 @@ stats_tab = {
 # Where to get the stats from
 net_stats_file = "/proc/net/dev"
 
+
 def create_desc(skel, prop):
     d = skel.copy()
     for k,v in prop.iteritems():
         d[k] = v
     return d
 
+
 def metric_init(params):
     global descriptors
     global INTERFACES
-    
+
 #    INTERFACES = params.get('interfaces')
     watch_interfaces = params.get('interfaces')
     excluded_interfaces = params.get('excluded_interfaces')
@@ -57,11 +59,10 @@ def metric_init(params):
         'value_type'  : 'float',
         'format'      : '%.4f',
         'units'       : '/s',
-        'slope'       : 'both', # zero|positive|negative|both
+        'slope'       : 'both',  # zero|positive|negative|both
         'description' : 'XXX',
         'groups'      : 'network',
         }
-
 
     for dev in INTERFACES:
         descriptors.append(create_desc(Desc_Skel, {
@@ -84,7 +85,7 @@ def metric_init(params):
                     "units"       : "pkts/sec",
                     "description" : "receive packets dropped per sec",
                     }))
-    
+
         descriptors.append(create_desc(Desc_Skel, {
                     "name"        : "tx_bytes_" + dev,
                     "units"       : "bytes/sec",
@@ -108,18 +109,19 @@ def metric_init(params):
 
     return descriptors
 
+
 def get_interfaces(watch_interfaces, excluded_interfaces):
 	global INTERFACES
-        
+
         # check if particular interfaces have been specifieid. Watch only those
         if watch_interfaces != "":
             INTERFACES = watch_interfaces.split(" ")
-            
+
         else:
 
 	    if excluded_interfaces != "":
 		excluded_if_list = excluded_interfaces.split(" ")
-        
+
             f = open(net_stats_file, "r")
             for line in f:
                 # Find only lines with :
@@ -141,7 +143,7 @@ def get_metrics():
 
 	try:
 	    file = open(net_stats_file, 'r')
-    
+
 	except IOError:
 	    return 0
 
@@ -161,7 +163,8 @@ def get_metrics():
         }
 
     return [METRICS, LAST_METRICS]
-    
+
+
 def get_delta(name):
     """Return change over time for the requested metric"""
 
@@ -182,7 +185,7 @@ def get_delta(name):
 	print name + " is less 0"
 	delta = 0
     except KeyError:
-      delta = 0.0      
+      delta = 0.0
 
     return delta
 

--- a/network/netiron/netiron.py
+++ b/network/netiron/netiron.py
@@ -31,6 +31,7 @@ oidDict = {
     'ifOutUcastPkts' : (1,3,6,1,2,1,2,2,1,17),
     }
 
+
 def get_metrics():
     """Return all metrics"""
 
@@ -55,6 +56,7 @@ def get_metrics():
 
     return [NIMETRICS, LAST_NIMETRICS]
 
+
 def get_delta(name):
     """Return change over time for the requested metric"""
 
@@ -71,9 +73,10 @@ def get_delta(name):
 
     return delta
 
+
 # Separate routine to perform SNMP queries and returns table (dict)
 def runSnmp(oidDict,ip):
-    
+
     # cmdgen only takes tuples, oid strings don't work
 #    ifIndex       = (1,3,6,1,2,1,2,2,1,1)
 #    ifName        = (1,3,6,1,2,1,31,1,1,1,1)
@@ -105,9 +108,10 @@ def runSnmp(oidDict,ip):
         else:
             return(varBindTable)
 
-def buildDict(oidDict,t,netiron): # passed a list of tuples, build's a dict based on the alias name
+
+def buildDict(oidDict,t,netiron):  # passed a list of tuples, build's a dict based on the alias name
     builtdict = {}
-    
+
     for line in t:
         #        if t[t.index(line)][2][1] != '':
         string = str(t[t.index(line)][2][1])
@@ -124,8 +128,9 @@ def buildDict(oidDict,t,netiron): # passed a list of tuples, build's a dict base
             builtdict[netiron+'_'+alias+'_pktsin'] = int(hcinpkt)
             hcoutpkt = str(t[t.index(line)][6][1])
             builtdict[netiron+'_'+alias+'_pktsout'] = int(hcoutpkt)
-            
+
     return builtdict
+
 
 # define_metrics will run an snmp query on an ipaddr, find interfaces, build descriptors and set spoof_host
 # define_metrics is called from metric_init
@@ -169,8 +174,8 @@ def define_metrics(Desc_Skel, ipaddr, netiron):
                         "spoof_host"  : spoof_string,
                         }))
 
-
     return descriptors
+
 
 def metric_init(params):
     global descriptors, Desc_Skel, _Worker_Thread, Debug, newdict
@@ -192,9 +197,9 @@ def metric_init(params):
         'slope'       : 'both',
         'description' : 'XXX',
         'groups'      : 'netiron',
-        }  
+        }
 
-    # Find all the netiron's passed in params    
+    # Find all the netiron's passed in params
     for para in params.keys():
          if para.startswith('netiron_'):
              #Get ipaddr + name of netirons from params
@@ -203,6 +208,7 @@ def metric_init(params):
              descriptors = define_metrics(Desc_Skel, ipaddr, name)
     #Return the descriptors back to gmond
     return descriptors
+
 
 def create_desc(skel, prop):
     d = skel.copy()
@@ -226,7 +232,7 @@ if __name__ == '__main__':
     while True:
         for d in descriptors:
             v = d['call_back'](d['name'])
-            print 'value for %s is %u' % (d['name'],  v)        
+            print 'value for %s is %u' % (d['name'],  v)
         print 'Sleeping 5 seconds'
         time.sleep(5)
 #exit(0)

--- a/network/netstats/python_modules/netstats.py
+++ b/network/netstats/python_modules/netstats.py
@@ -16,7 +16,8 @@ stats_files = [ "/proc/net/netstat", "/proc/net/snmp" ]
 LAST_METRICS = copy.deepcopy(METRICS)
 METRICS_CACHE_MAX = 5
 
-stats_pos = {} 
+stats_pos = {}
+
 
 def get_metrics():
     """Return all metrics"""
@@ -30,10 +31,10 @@ def get_metrics():
 	for file in stats_files:
 	    try:
 		file = open(file, 'r')
-	
+
 	    except IOError:
 		return 0
-    
+
 	    # convert to dict
 	    metrics = {}
 	    for line in file:
@@ -66,7 +67,7 @@ def get_value(name):
 
     metrics = get_metrics()[0]
 
-    name = name[len(NAME_PREFIX):] # remove prefix from name
+    name = name[len(NAME_PREFIX):]  # remove prefix from name
 
     try:
         result = metrics['data'][name]
@@ -92,7 +93,7 @@ def get_delta(name):
 	print name + " is less 0"
 	delta = 0
     except KeyError:
-      delta = 0.0      
+      delta = 0.0
 
     return delta
 
@@ -111,6 +112,7 @@ def get_tcploss_percentage(name):
       pct = 0.0
 
     return pct
+
 
 def get_tcpattemptfail_percentage(name):
 
@@ -150,6 +152,7 @@ def create_desc(skel, prop):
         d[k] = v
     return d
 
+
 def metric_init(params):
     global descriptors, metric_map, Desc_Skel
 
@@ -162,7 +165,7 @@ def metric_init(params):
         'value_type'  : 'float',
         'format'      : '%.5f',
         'units'       : 'count/s',
-        'slope'       : 'both', # zero|positive|negative|both
+        'slope'       : 'both',  # zero|positive|negative|both
         'description' : 'XXX',
         'groups'      : 'XXX',
         }
@@ -175,25 +178,25 @@ def metric_init(params):
     for file in stats_files:
 	try:
 	    file = open(file, 'r')
-    
+
 	except IOError:
 	    return 0
-	
+
 	# Find mapping
 	for line in file:
-	    # Lines with 
+	    # Lines with
 	    if not re.match("(.*): [0-9]", line):
 		count = 0
 		mapping = re.split("\s+", line)
 		metric_group = mapping[0].replace(":", "").lower()
 		stats_pos[metric_group] = dict()
 		for metric in mapping:
-		    # Skip first 
+		    # Skip first
 		    if count > 0 and metric != "":
 			lowercase_metric = metric.lower()
 			stats_pos[metric_group][count] = lowercase_metric
 		    count += 1
-    
+
 	file.close()
 
     for group in stats_pos:
@@ -220,7 +223,6 @@ def metric_init(params):
         'groups'      : 'tcpext'
 	}))
 
-
     descriptors.append(create_desc(Desc_Skel, {
 	"name"       : "tcp_retrans_percentage",
 	"call_back"  : get_retrans_percentage,
@@ -230,6 +232,7 @@ def metric_init(params):
 	}))
 
     return descriptors
+
 
 def metric_cleanup():
     '''Clean up the metric module.'''

--- a/nfsstats/python_modules/nfsstats.py
+++ b/nfsstats/python_modules/nfsstats.py
@@ -8,6 +8,7 @@ import syslog
 import sys
 import string
 
+
 def test_proc3( p_file ):
 
     """
@@ -102,6 +103,7 @@ configtable = [
     }
 ]
 
+
 #  Ganglia will call metric_init(), which should return a dictionary for each thing that it
 #  should monitor, including the name of the callback function to get the current value.
 def metric_init(params):
@@ -143,7 +145,6 @@ def metric_init(params):
 		file_str = configtable[i]['names'][name]['file']
             else:
 		file_str = configtable[i]['file']
-		
 
             descriptors.append({
                 'name': configtable[i]['prefix'] + name,
@@ -161,7 +162,7 @@ def metric_init(params):
             })
             #  And get current value cached as previous value, for future comparisons.
             (ts, value) =  get_value(configtable[i]['prefix'] + name)
-            old_values[configtable[i]['prefix'] + name] = { 
+            old_values[configtable[i]['prefix'] + name] = {
                 'time':ts,
                 'value':value
             }
@@ -169,9 +170,11 @@ def metric_init(params):
     #  Pass ganglia the complete list of dictionaries.
     return descriptors
 
+
 #  Ganglia will call metric_cleanup() when it exits.
 def metric_cleanup():
     pass
+
 
 #  metric_init() registered this as the callback function.
 def call_back(name):
@@ -179,8 +182,8 @@ def call_back(name):
 
     #  Get new value
     (new_time, new_value) = get_value(name)
- 
-    #  Calculate rate of change 
+
+    #  Calculate rate of change
     try:
         rate = (new_value - old_values[name]['value'])/(new_time - old_values[name]['time'])
     except ZeroDivisionError:
@@ -190,6 +193,7 @@ def call_back(name):
     old_values[name]['value'] = new_value
     old_values[name]['time'] = new_time
     return rate
+
 
 def get_value(name):
     global descriptors
@@ -213,10 +217,11 @@ def get_value(name):
             sum_value = sum_value + int(f)
 
         m_value = sum_value
-    
+
     #  Return time and value.
     ts = time.time()
     return (ts, int(m_value))
+
 
 def debug(level, text):
     global verboselevel

--- a/nginx_status/python_modules/nginx_status.py
+++ b/nginx_status/python_modules/nginx_status.py
@@ -16,6 +16,7 @@ logging.basicConfig(level=logging.ERROR)
 
 _Worker_Thread = None
 
+
 class UpdateNginxThread(threading.Thread):
 
     def __init__(self, params):
@@ -173,6 +174,7 @@ class UpdateNginxThread(threading.Thread):
             logging.warning('failed to fetch ' + name)
             return 0
 
+
 def metric_init(params):
     logging.debug('init: ' + str(params))
     global _Worker_Thread
@@ -240,13 +242,16 @@ def metric_init(params):
 
     return descriptors
 
+
 def metric_of(name):
     global _Worker_Thread
     return _Worker_Thread.metric_of(name)
 
+
 def setting_of(name):
     global _Worker_Thread
     return _Worker_Thread.setting_of(name)
+
 
 def metric_cleanup():
     global _Worker_Thread

--- a/openstack_monitor/python_modules/compute-metrics.py
+++ b/openstack_monitor/python_modules/compute-metrics.py
@@ -134,6 +134,7 @@ def hypervisor_getter(worker):
     global _hypervisor_name
     return _hypervisor_name
 
+
 def metric_init(params):
     global __worker__
 
@@ -207,6 +208,7 @@ def metric_init(params):
     return [instances, version, compute, hypervisor,
             run_services, reg_services]
 
+
 def metric_cleanup():
     """Clean up the metric module."""
     __worker__.shutdown()
@@ -223,4 +225,3 @@ if __name__ == '__main__':
         os._exit(1)
     finally:
         metric_cleanup()
-

--- a/passenger/python_modules/passenger.py
+++ b/passenger/python_modules/passenger.py
@@ -14,12 +14,14 @@ import re
 descriptors = list()
 Desc_Skel   = {}
 _Worker_Thread = None
-_Lock = threading.Lock() # synchronization lock
+_Lock = threading.Lock()  # synchronization lock
 Debug = False
+
 
 def dprint(f, *v):
     if Debug:
         print >>sys.stderr, "DEBUG: "+f % v
+
 
 def floatable(str):
     try:
@@ -27,6 +29,7 @@ def floatable(str):
         return True
     except:
         return False
+
 
 class UpdateMetricThread(threading.Thread):
 
@@ -75,7 +78,7 @@ class UpdateMetricThread(threading.Thread):
 
     def update_metric(self):
         status_output = timeout_command(self.status, self.timeout)
-        status_output += timeout_command(self.memory_stats, self.timeout)[-1:] # to get last line of memory output
+        status_output += timeout_command(self.memory_stats, self.timeout)[-1:]  # to get last line of memory output
         dprint("%s", status_output)
         for line in status_output:
           for (name,regex) in self.status_regex.iteritems():
@@ -93,6 +96,7 @@ class UpdateMetricThread(threading.Thread):
             _Lock.release()
         return val
 
+
 def metric_init(params):
     global descriptors, Desc_Skel, _Worker_Thread, Debug
 
@@ -109,7 +113,7 @@ def metric_init(params):
         'value_type'  : 'uint',
         'format'      : '%u',
         'units'       : 'XXX',
-        'slope'       : 'XXX', # zero|positive|negative|both
+        'slope'       : 'XXX',  # zero|positive|negative|both
         'description' : 'XXX',
         'groups'      : 'passenger',
         }
@@ -168,17 +172,21 @@ def metric_init(params):
 
     return descriptors
 
+
 def create_desc(skel, prop):
     d = skel.copy()
     for k,v in prop.iteritems():
         d[k] = v
     return d
 
+
 def metric_of(name):
     return _Worker_Thread.metric_of(name)
 
+
 def metric_cleanup():
     _Worker_Thread.shutdown()
+
 
 def timeout_command(command, timeout):
     """call shell-command and either return its output or kill it

--- a/php_fpm/python_modules/php_fpm.py
+++ b/php_fpm/python_modules/php_fpm.py
@@ -28,6 +28,7 @@ import urllib2
 
 logging.basicConfig(level=logging.ERROR)
 
+
 class FCGIApp(flup.client.fcgi_app.FCGIApp):
     ### HACK: reduce the timeout to 2 seconds
     def _getConnection(self):
@@ -155,6 +156,7 @@ class FCGIApp(flup.client.fcgi_app.FCGIApp):
         return [result]
 
 _Worker_Thread = None
+
 
 class UpdatePhpFpmThread(threading.Thread):
 
@@ -330,6 +332,7 @@ class UpdatePhpFpmThread(threading.Thread):
             logging.warning('failed to fetch ' + name)
             return 0
 
+
 def _create_descriptors(params):
     METRIC_DEFAULTS = {
         'time_max': 60,
@@ -399,6 +402,7 @@ def _create_descriptors(params):
 
     return descriptors
 
+
 def metric_init(params):
     logging.debug('init: ' + str(params))
     global _Worker_Thread
@@ -420,9 +424,11 @@ def metric_of(name):
     global _Worker_Thread
     return _Worker_Thread.metric_of(name)
 
+
 def setting_of(name):
     global _Worker_Thread
     return _Worker_Thread.setting_of(name)
+
 
 def metric_cleanup():
     global _Worker_Thread

--- a/procstat/python_modules/procstat.py
+++ b/procstat/python_modules/procstat.py
@@ -124,6 +124,7 @@ PAGE_SIZE=os.sysconf('SC_PAGE_SIZE')
 
 PROCESSES = {}
 
+
 def readCpu(pid):
 	try:
 		stat = file('/proc/' + pid + '/stat', 'rt').readline().split()
@@ -136,6 +137,7 @@ def readCpu(pid):
 	except:
 		logging.warning('failed to get (' + str(pid) + ') stats')
 		return 0
+
 
 def get_pgid(proc):
 	logging.debug('getting pgid for process: ' + proc)
@@ -183,6 +185,7 @@ def get_pgid(proc):
 	else:
 		return ERROR
 
+
 def get_pgroup(ppid, pgid):
 	'''Return a list of pids having the same pgid, with the first in the list being the parent pid.'''
 	logging.debug('getting pids for ppid/pgid: ' + ppid + '/' + pgid)
@@ -206,6 +209,7 @@ def get_pgroup(ppid, pgid):
 	except:
 		logging.warning('failed getting pids')
 
+
 def get_rss(pids):
 	logging.debug('getting rss for pids')
 
@@ -224,6 +228,7 @@ def get_rss(pids):
 	rss *= PAGE_SIZE
 	return rss
 
+
 def test(params):
 	global PROCESSES, MAX_UPDATE_TIME
 
@@ -235,7 +240,7 @@ def test(params):
 
 	for proc,val in PROCESSES.items():
 		print('')
-		print(' Testing ' + proc + ': ' + val) 
+		print(' Testing ' + proc + ': ' + val)
 
 		try:
 			(ppid, pgid) = get_pgid(proc)
@@ -254,10 +259,11 @@ def test(params):
 
 	logging.debug('success testing')
 
+
 def update_stats():
 	logging.debug('updating stats')
 	global last_update, stats, last_val
-	
+
 	cur_time = time.time()
 
 	if cur_time - last_update < MAX_UPDATE_TIME:
@@ -294,7 +300,7 @@ def update_stats():
 		proc_time = 0
 		for p in pids:
 			proc_time += readCpu(p)
-		
+
 		logging.debug(' proc_time: ' + str(proc_time) + ' cpu_time: ' + str(cpu_time))
 
 		# do we have an old value to calculate with?
@@ -311,14 +317,15 @@ def update_stats():
 		last_val[proc]['proc_time'] = proc_time
 
 		#####
-		# Update Mem utilization	
+		# Update Mem utilization
 		rss = get_rss(pids)
 		stats[proc]['mem'] = rss
-	
+
 	logging.debug('success refreshing stats')
 	logging.debug('stats: ' + str(stats))
 
 	return True
+
 
 def get_stat(name):
 	logging.debug('getting stat: ' + name)
@@ -349,6 +356,7 @@ def get_stat(name):
 	else:
 		return 0
 
+
 def metric_init(params):
 	global descriptors
 	global PROCESSES
@@ -358,7 +366,7 @@ def metric_init(params):
 	PROCESSES = params
 
 	#for proc,regex in PROCESSES.items():
-		
+
 	update_stats()
 
 	descriptions = dict(
@@ -402,6 +410,7 @@ def metric_init(params):
 
 	return descriptors
 
+
 def display_proc_stat(pid):
 	try:
 		stat = file('/proc/' + pid + '/stat', 'rt').readline().split()
@@ -426,12 +435,13 @@ def display_proc_stat(pid):
 		print('failed to get /proc/' + pid + '/stat')
 		print(traceback.print_exc(file=sys.stdout))
 
+
 def display_proc_statm(pid):
 	try:
 		statm = file('/proc/' + pid + '/statm', 'rt').readline().split()
 
 		fields = [
-			'size', 'rss', 'share', 'trs', 'drs', 'lrs' ,'dt' 
+			'size', 'rss', 'share', 'trs', 'drs', 'lrs' ,'dt'
 		]
 
 		# Display them
@@ -443,6 +453,7 @@ def display_proc_statm(pid):
 	except:
 		print('failed to get /proc/' + pid + '/statm')
 		print(traceback.print_exc(file=sys.stdout))
+
 
 def metric_cleanup():
 	logging.shutdown()
@@ -480,7 +491,7 @@ if __name__ == '__main__':
 	for proc in _procs:
 		params[proc] = _val[i]
 		i += 1
-	
+
 	if options.test:
 		test(params)
 		update_stats()
@@ -505,5 +516,3 @@ if __name__ == '__main__':
 			cmd = "%s --conf=%s --value='%s' --units='%s' --type='%s' --name='%s' --slope='%s'" % \
 				(options.gmetric_bin, options.gmond_conf, v, d['units'], value_type, d['name'], d['slope'])
 			os.system(cmd)
-
-

--- a/rabbit/python_modules/rabbitmq.py
+++ b/rabbit/python_modules/rabbitmq.py
@@ -8,7 +8,7 @@ from string import Template
 import itertools
 import threading
 
-global url, descriptors, last_update, vhost, username, password, url_template, result, result_dict, keyToPath 
+global url, descriptors, last_update, vhost, username, password, url_template, result, result_dict, keyToPath
 INTERVAL = 10
 descriptors = list()
 username, password = "guest", "guest"
@@ -28,7 +28,7 @@ STATS = ['nodes', 'queues']
 keyToPath['rmq_messages_ready'] = "%s.messages_ready"
 keyToPath['rmq_messages_unacknowledged'] = "%s.messages_unacknowledged"
 keyToPath['rmq_backing_queue_ack_egress_rate'] = "%s.backing_queue_status.avg_ack_egress_rate"
-keyToPath['rmq_backing_queue_ack_ingress_rate'] = "%s.backing_queue_status.avg_ack_ingress_rate" 
+keyToPath['rmq_backing_queue_ack_ingress_rate'] = "%s.backing_queue_status.avg_ack_ingress_rate"
 keyToPath['rmq_backing_queue_egress_rate'] = "%s.backing_queue_status.avg_egress_rate"
 keyToPath['rmq_backing_queue_ingress_rate'] = "%s.backing_queue_status.avg_ingress_rate"
 keyToPath['rmq_backing_queue_mirror_senders'] = "%s.backing_queue_status.mirror_senders"
@@ -55,19 +55,18 @@ keyToPath['rmq_fd_used'] = "%s.fd_used"
 keyToPath['rmq_mem_used'] = "%s.mem_used"
 keyToPath['rmq_proc_used'] = "%s.proc_used"
 keyToPath['rmq_sockets_used'] = "%s.sockets_used"
-keyToPath['rmq_mem_alarm'] = "%s.mem_alarm" #Boolean
+keyToPath['rmq_mem_alarm'] = "%s.mem_alarm"  # Boolean
 keyToPath['rmq_mem_binary'] = "%s.mem_binary"
 keyToPath['rmq_mem_code'] = "%s.mem_code"
 keyToPath['rmq_mem_proc_used'] = "%s.mem_proc_used"
-keyToPath['rmq_running'] = "%s.running" #Boolean
+keyToPath['rmq_running'] = "%s.running"  # Boolean
 
 NODE_METRICS = ['rmq_disk_free', 'rmq_mem_used', 'rmq_disk_free_alarm', 'rmq_running', 'rmq_proc_used', 'rmq_mem_proc_used', 'rmq_fd_used', 'rmq_mem_alarm', 'rmq_mem_code', 'rmq_mem_binary', 'rmq_sockets_used']
-	
-
 
 
 def metric_cleanup():
     pass
+
 
 def dig_it_up(obj,path):
     try:
@@ -76,6 +75,7 @@ def dig_it_up(obj,path):
     except:
         print "Exception"
         return False
+
 
 def refreshStats(stats = ('nodes', 'queues'), vhosts = ['/']):
 
@@ -109,36 +109,40 @@ def refreshStats(stats = ('nodes', 'queues'), vhosts = ['/']):
 
     return compiled_results
 
+
 def validatedResult(value):
     if not isInstance(value, bool):
         return float(value)
     else:
         return None
 
+
 def list_queues(vhost):
     global compiled_results
     queues = compiled_results[('queues', vhost)].keys()
     return queues
+
 
 def list_nodes():
     global compiled_results
     nodes = compiled_results[('nodes', '/')].keys()
     return nodes
 
+
 def getQueueStat(name):
     refreshStats(stats = STATS, vhosts = vhosts)
     #Split a name like "rmq_backing_queue_ack_egress_rate.access"
-    
+
     #handle queue names with . in them
     print name
     split_name, vhost = name.split("#")
     split_name = split_name.split(".")
     stat_name = split_name[0]
     queue_name = ".".join(split_name[1:])
-    
+
     # Run refreshStats to get the result object
     result = compiled_results[('queues', vhost)]
-    
+
     value = dig_it_up(result, keyToPath[stat_name] % queue_name)
     print name, value
 
@@ -149,6 +153,7 @@ def getQueueStat(name):
         value = 0
 
     return float(value)
+
 
 def getNodeStat(name):
     refreshStats(stats = STATS, vhosts = vhosts)
@@ -167,6 +172,7 @@ def getNodeStat(name):
 
     return float(value)
 
+
 def product(*args, **kwds):
     # replacement for itertools.product
     # product('ABCD', 'xy') --> Ax Ay Bx By Cx Cy Dx Dy
@@ -176,7 +182,8 @@ def product(*args, **kwds):
         result = [x+[y] for x in result for y in pool]
     for prod in result:
         yield tuple(prod)
-    
+
+
 def metric_init(params):
     ''' Create the metric definition object '''
     global descriptors, stats, vhost, username, password, urlstring, url_template, compiled_results, STATS, vhosts
@@ -190,7 +197,7 @@ def metric_init(params):
     username, password = params['username'], params['password']
     host = params['host']
     port = params['port']
-    
+
     url = 'http://%s:%s/api/$stats/$vhost' % (host,port)
     base_url = 'http://%s:%s/api' % (host,port)
     password_mgr = urllib2.HTTPPasswordMgrWithDefaultRealm()
@@ -209,8 +216,6 @@ def metric_init(params):
             metric_handler.timestamp = time.time()
             return refreshStats(stats = STATS, vhosts = vhosts)
 
-            
-
     def create_desc(prop):
 	d = {
 	    'name'        : 'XXX',
@@ -228,12 +233,11 @@ def metric_init(params):
 	    d[k] = v
 	return d
 
-
     def buildQueueDescriptors():
         for vhost, metric in product(vhosts, QUEUE_METRICS):
             queues = list_queues(vhost)
             for queue in queues:
-                name = "%s.%s#%s" % (metric, queue, vhost)   
+                name = "%s.%s#%s" % (metric, queue, vhost)
 		print name
 		d1 = create_desc({'name': name.encode('ascii','ignore'),
 		    'call_back': getQueueStat,
@@ -245,7 +249,7 @@ def metric_init(params):
 		    'groups' : 'rabbitmq,queue'})
 		print d1
 		descriptors.append(d1)
-    
+
     def buildNodeDescriptors():
         for metric in NODE_METRICS:
 	    for node in list_nodes():
@@ -258,19 +262,20 @@ def metric_init(params):
 		    'slope': 'both',
 		    'format': '%f',
 		    'description': 'Node_Metric',
-		    'groups' : 'rabbitmq,node'}) 
+		    'groups' : 'rabbitmq,node'})
                 print d2
 		descriptors.append(d2)
 
     buildQueueDescriptors()
     buildNodeDescriptors()
     # buildTestNodeStat()
-	
+
     return descriptors
+
 
 def metric_cleanup():
     pass
-  
+
 
 if __name__ == "__main__":
     url = 'http://%s:%s@localhost:15672/api/$stats' % (username, password)
@@ -280,5 +285,5 @@ if __name__ == "__main__":
     result = refreshStats(stats = ('queues', 'nodes'), vhosts = ('/'))
     print '***'*10
     getQueueStat('rmq_backing_queue_ack_egress_rate.nfl_client#/')
-    getNodeStat('rmq_disk_free.rmqone@inrmq01d1#/') 
+    getNodeStat('rmq_disk_free.rmqone@inrmq01d1#/')
     getNodeStat('rmq_mem_used.rmqone@inrmq01d1#/')

--- a/recoverpoint/recoverpoint.py
+++ b/recoverpoint/recoverpoint.py
@@ -26,6 +26,7 @@ NIMETRICS_CACHE_MAX = 10
 
 ipaddr = ''
 
+
 #Example of data structure:
 #{'RPA statistics': {'Site 1 RPA 1': {'Compression CPU usage': '0.00%',
 #                                       'Latency (ms)': 12,
@@ -34,7 +35,6 @@ ipaddr = ''
 #                                                                   'WAN': '432 bps'},
 #                                                   'Application (writes)': 0,
 #                                                   'Compression': 0}},
-
 def define_metrics(Desc_Skel, statsDict):
     for rpa in statsDict['RPA statistics']:
         #pprint.pprint(statsDict['RPA statistics'][rpa])
@@ -92,7 +92,7 @@ def define_metrics(Desc_Skel, statsDict):
                         "description" : group + ' WAN Traffic',
                         "groups"      : 'WAN Traffic',
                         }))
-            
+
             #Define CG Lag metrics
             for lagfields in statsDict['Group'][group]['Link stats'][repname]['Replication']['Lag']:
                 lagunit = ''
@@ -108,15 +108,17 @@ def define_metrics(Desc_Skel, statsDict):
                             "description" : group + ' Lag ' + lagunit,
                             "groups"      : 'Lag',
                             }))
-                
+
     return descriptors
+
 
 def create_desc(skel, prop):
     d = skel.copy()
     for k,v in prop.iteritems():
         d[k] = v
     return d
-    
+
+
 def get_metrics(name):
     global NIMETRICS,ipaddr
     # if interval since last check > NIMETRICS_CACHE_MAX get metrics again
@@ -169,12 +171,12 @@ def get_metrics(name):
                         minindex = protimelist.index('min')
                         protectmins = protectmins + int(protimelist[int(minindex) -1])
                     metrics[group + '_Protection_Window'] = float(protectmins)
-                                                     
+
             #CG Lag and WAN stats are in the Link stats section
             for repname in rawmetrics['Group'][group]['Link stats']:
                 #Get CG WAN metrics (remove 'Mbps' from end + convert to float and then bits)
                 metrics[group + '_WAN_Traffic'] = float(rawmetrics['Group'][group]['Link stats'][repname]['Replication']['WAN traffic'][:-4]) * 1024 * 1024
-                
+
                 #Get CG Lag metrics
                 for lagfields in rawmetrics['Group'][group]['Link stats'][repname]['Replication']['Lag']:
                     if 'Data' in lagfields:
@@ -190,7 +192,7 @@ def get_metrics(name):
                         elif 'GB' in unitstr:
                             amount = amount * 1024 * 1024 * 1024
                         metrics[group + '_Lag_' + lagfields] = amount
-                        
+
                     elif 'Time' in lagfields:
                         #Strip 'sec' from value, convert to float.
                         lagtime = float(rawmetrics['Group'][group]['Link stats'][repname]['Replication']['Lag'][lagfields][:-3])
@@ -198,7 +200,7 @@ def get_metrics(name):
                     else:
                         #Writes Lag
                         metrics[group + '_Lag_' + lagfields] = float(rawmetrics['Group'][group]['Link stats'][repname]['Replication']['Lag'][lagfields])
-                        
+
         NIMETRICS = {
             'time': time.time(),
             'data': metrics
@@ -206,8 +208,7 @@ def get_metrics(name):
     else:
         metrics = NIMETRICS['data']
     return metrics[name]
-    
-    
+
 
 def metric_init(params):
     global descriptors, Desc_Skel, ipaddr
@@ -227,7 +228,7 @@ def metric_init(params):
         'description' : 'XXX',
         'groups'      : 'netiron',
         'spoof_host'  : spoof_string
-        }  
+        }
 
     sshcon = paramiko.SSHClient()
     sshcon.set_missing_host_key_policy(paramiko.AutoAddPolicy())
@@ -245,7 +246,7 @@ def metric_init(params):
 if __name__ == '__main__':
     params = {
         'mgmtip' : '192.168.1.100',
-        
+
               }
     descriptors = metric_init(params)
     pprint.pprint(descriptors)
@@ -253,7 +254,7 @@ if __name__ == '__main__':
     while True:
         for d in descriptors:
             v = d['call_back'](d['name'])
-            print 'value for %s is %u' % (d['name'],  v)        
+            print 'value for %s is %u' % (d['name'],  v)
         print 'Sleeping 5 seconds'
         time.sleep(5)
 #exit(0)

--- a/redis-gmond/python_modules/redis-gmond.py
+++ b/redis-gmond/python_modules/redis-gmond.py
@@ -5,6 +5,7 @@ import time
 #logging.basicConfig(level=logging.DEBUG, format="%(asctime)s - %(name)s - %(levelname)s\t Thread-%(thread)d - %(message)s", filename='/tmp/gmond.log', filemode='w')
 #logging.debug('starting up')
 
+
 def metric_handler(name):
 
     # Update from Redis.  Don't thrash.
@@ -57,7 +58,7 @@ def metric_handler(name):
                           metric_handler.prev_total_commands = int(v)
                           v = cps
                   #logging.debug("submittincg metric %s is %s" % (n, int(v)))
-                  metric_handler.info[n] = int(v) # TODO Use value_type.
+                  metric_handler.info[n] = int(v)  # TODO Use value_type.
         except Exception, e:
             #logging.debug("caught exception %s" % e)
             pass
@@ -66,6 +67,7 @@ def metric_handler(name):
 
     #logging.debug("returning metric_handl: %s %s %s" % (metric_handler.info.get(name, 0), metric_handler.info, metric_handler))
     return metric_handler.info.get(name, 0)
+
 
 def metric_init(params={}):
     metric_handler.host = params.get("host", "127.0.0.1")
@@ -109,6 +111,7 @@ def metric_init(params={}):
         descriptor.update(updates)
         metric_handler.descriptors[name] = descriptor
     return metric_handler.descriptors.values()
+
 
 def metric_cleanup():
     pass

--- a/riak/riak.py
+++ b/riak/riak.py
@@ -12,12 +12,14 @@ import json
 descriptors = list()
 Desc_Skel   = {}
 _Worker_Thread = None
-_Lock = threading.Lock() # synchronization lock
+_Lock = threading.Lock()  # synchronization lock
 Debug = False
+
 
 def dprint(f, *v):
     if Debug:
         print >>sys.stderr, "DEBUG: "+f % v
+
 
 def floatable(str):
     try:
@@ -25,6 +27,7 @@ def floatable(str):
         return True
     except:
         return False
+
 
 class UpdateMetricThread(threading.Thread):
 
@@ -87,6 +90,7 @@ class UpdateMetricThread(threading.Thread):
             _Lock.release()
         return val
 
+
 def metric_init(params):
     global descriptors, Desc_Skel, _Worker_Thread, Debug
 
@@ -103,7 +107,7 @@ def metric_init(params):
         'value_type'  : 'uint',
         'format'      : '%u',
         'units'       : 'XXX',
-        'slope'       : 'XXX', # zero|positive|negative|both
+        'slope'       : 'XXX',  # zero|positive|negative|both
         'description' : 'XXX',
         'groups'      : 'riak',
         }
@@ -276,14 +280,17 @@ def metric_init(params):
 
     return descriptors
 
+
 def create_desc(skel, prop):
     d = skel.copy()
     for k,v in prop.iteritems():
         d[k] = v
     return d
 
+
 def metric_of(name):
     return _Worker_Thread.metric_of(name)
+
 
 def metric_cleanup():
     _Worker_Thread.shutdown()

--- a/scribe/python_modules/scribe_stats.py
+++ b/scribe/python_modules/scribe_stats.py
@@ -14,9 +14,11 @@ Debug = False
 last_mps_timestamp = float(0)
 last_mps_value = 0
 
+
 def dprint(f, *v):
     if Debug:
         print >>sys.stderr, "DEBUG: "+f % v
+
 
 def GetOverallMessagesPerSecond(name):
     dprint("%s", name)
@@ -50,6 +52,7 @@ def GetOverallMessagesPerSecond(name):
 
     return float(value_diff / elapsed)
 
+
 def run_cmd(arglist):
     '''Run a command and capture output.'''
 
@@ -61,11 +64,12 @@ def run_cmd(arglist):
 
     return (p.returncode, output)
 
+
 def metric_init(params):
     '''Create the metric definition dictionary object for each metric.'''
 
     global descriptors
-    
+
     d1 = {
         'name': 'scribe_overall_messages_per_second',
         'call_back': GetOverallMessagesPerSecond,
@@ -79,7 +83,8 @@ def metric_init(params):
         }
 
     descriptors = [d1]
-    return descriptors    
+    return descriptors
+
 
 def metric_cleanup():
     '''Clean up the metric module.'''
@@ -87,10 +92,10 @@ def metric_cleanup():
 
 if __name__ == '__main__':
     metric_init({})
-    
+
     # setup last timestamp as 10 seconds ago
     last_mps_timestamp = time.time() - 10
-    
+
     for d in descriptors:
         v = d['call_back'](d['name'])
         print '%s: %s' % (d['name'],  v)

--- a/squid/python_modules/squid.py
+++ b/squid/python_modules/squid.py
@@ -20,6 +20,7 @@ squid_stats_last = {}
 
 MIN_UPDATE_INTERVAL = 30          # Minimum update interval in seconds
 
+
 def collect_stats():
     #logging.debug('collect_stats()')
     global last_update
@@ -54,7 +55,7 @@ def collect_stats():
                 value = value.lstrip()
                 rawstats[key] = value
         else:
-            match = re.search("(\d+)\s+(.*)$",stat) # reversed "value key" line
+            match = re.search("(\d+)\s+(.*)$",stat)  # reversed "value key" line
             if match:
                 rawstats[match.group(2)] = match.group(1)
 
@@ -70,8 +71,8 @@ def collect_stats():
                         squid_stats[metric] = rawstat
                 else:
                     squid_stats[metric] = rawstat
-        if squid_stats.has_key(metric): # Strip trailing non-num text
-            if metric != 'cacheVersionId': # version is special case
+        if squid_stats.has_key(metric):  # Strip trailing non-num text
+            if metric != 'cacheVersionId':  # version is special case
                 match = re.match('([0-9.]+)',squid_stats[metric]);
                 squid_stats[metric] = float(match.group(1))
                 if stats_descriptions[metric]['type'] == 'integer':
@@ -92,6 +93,7 @@ def collect_stats():
     #logging.debug('collect_stats done')
     #logging.debug('squid_stats: ' + str(squid_stats))
 
+
 def get_stat(name):
     #logging.info("get_stat(%s)" % name)
     global squid_stats
@@ -103,7 +105,7 @@ def get_stat(name):
             label = name[6:]
         else:
             lable = name
-            
+
             #logging.debug("fetching %s" % label)
         try:
             #logging.info("got %4.2f" % squid_stats[label])
@@ -468,15 +470,16 @@ def metric_init(params):
                 'description': label,
                 'groups': 'squid',
                 }
-            
+
             d.update(stats_descriptions[label])
-            
+
             descriptors.append(d)
-            
+
         #else:
             #logging.error("skipped " + label)
-            
+
     return descriptors
+
 
 def metric_cleanup():
     #logging.shutdown()
@@ -493,4 +496,3 @@ if __name__ == '__main__':
             print 'value for %s is %d %s' % (d['name'],  v, d['units'])
         else:
             print 'value for %s is %4.2f %s' % (d['name'],  v, d['units'])
-

--- a/ssl/entropy/python_modules/entropy.py
+++ b/ssl/entropy/python_modules/entropy.py
@@ -3,7 +3,8 @@ import sys
 
 entropy_file = "/proc/sys/kernel/random/entropy_avail"
 
-def metrics_handler(name):  
+
+def metrics_handler(name):
     try:
         f = open(entropy_file, 'r')
 
@@ -14,6 +15,7 @@ def metrics_handler(name):
         line = l
 
     return int(line)
+
 
 def metric_init(params):
     global descriptors, node_id
@@ -31,6 +33,7 @@ def metric_init(params):
     descriptors = [dict]
 
     return descriptors
+
 
 def metric_cleanup():
     '''Clean up the metric module.'''

--- a/system/cpu_stats/python_modules/cpu_stats.py
+++ b/system/cpu_stats/python_modules/cpu_stats.py
@@ -27,13 +27,13 @@ softirq_pos = {
 LAST_METRICS = copy.deepcopy(METRICS)
 METRICS_CACHE_MAX = 5
 
-
-
 stat_file = "/proc/stat"
 
 ###############################################################################
 #
 ###############################################################################
+
+
 def get_metrics():
     """Return all metrics"""
 
@@ -43,7 +43,7 @@ def get_metrics():
 
 	try:
 	    file = open(stat_file, 'r')
-    
+
 	except IOError:
 	    return 0
 
@@ -70,7 +70,7 @@ def get_value(name):
 
     NAME_PREFIX="cpu_"
 
-    name = name.replace(NAME_PREFIX,"") # remove prefix from name
+    name = name.replace(NAME_PREFIX,"")  # remove prefix from name
 
     try:
         result = metrics['data'][name][0]
@@ -88,7 +88,7 @@ def get_delta(name):
 
     NAME_PREFIX="cpu_"
 
-    name = name.replace(NAME_PREFIX,"") # remove prefix from name
+    name = name.replace(NAME_PREFIX,"")  # remove prefix from name
 
     if name == "procs_created":
       name = "processes"
@@ -99,9 +99,10 @@ def get_delta(name):
 	print name + " is less 0"
 	delta = 0
     except KeyError:
-      delta = 0.0      
+      delta = 0.0
 
     return delta
+
 
 ##############################################################################
 # SoftIRQ has multiple values which are defined in a dictionary at the top
@@ -114,7 +115,7 @@ def get_softirq_delta(name):
 
     NAME_PREFIX="softirq_"
 
-    name = name[len(NAME_PREFIX):] # remove prefix from name
+    name = name[len(NAME_PREFIX):]  # remove prefix from name
 
     index = softirq_pos[name]
 
@@ -124,10 +125,9 @@ def get_softirq_delta(name):
 	print name + " is less 0"
 	delta = 0
     except KeyError:
-      delta = 0.0      
+      delta = 0.0
 
     return delta
-
 
 
 def create_desc(skel, prop):
@@ -135,6 +135,7 @@ def create_desc(skel, prop):
     for k,v in prop.iteritems():
         d[k] = v
     return d
+
 
 def metric_init(params):
     global descriptors, metric_map, Desc_Skel
@@ -149,7 +150,7 @@ def metric_init(params):
         'value_type'  : 'float',
         'format'      : '%.0f',
         'units'       : 'XXX',
-        'slope'       : 'both', # zero|positive|negative|both
+        'slope'       : 'both',  # zero|positive|negative|both
         'description' : '',
         'groups'      : 'cpu',
         }
@@ -255,15 +256,15 @@ def metric_init(params):
                 "call_back"   : get_softirq_delta
                 }))
 
-
     # We need a metric_map that maps metric_name to the index in /proc/meminfo
     metric_map = {}
-    
+
     for d in descriptors:
 	metric_name = d['name']
         metric_map[metric_name] = { "name": d['orig_name'], "units": d['units'] }
-        
+
     return descriptors
+
 
 def metric_cleanup():
     '''Clean up the metric module.'''

--- a/system/mem_fragmentation/python_modules/mem_fragmentation.py
+++ b/system/mem_fragmentation/python_modules/mem_fragmentation.py
@@ -19,7 +19,7 @@ buddyinfo_file = "/proc/buddyinfo"
 LAST_METRICS = copy.deepcopy(METRICS)
 METRICS_CACHE_MAX = 5
 
-stats_pos = {} 
+stats_pos = {}
 
 stats_pos = {
   '0004k' : 4,
@@ -36,6 +36,7 @@ stats_pos = {
 }
 
 zones = []
+
 
 def get_node_zones():
     """Return all zones metrics"""
@@ -64,7 +65,7 @@ def get_metrics():
 
 	try:
 	    file = open(buddyinfo_file, 'r')
-    
+
 	except IOError:
 	    return 0
 
@@ -79,7 +80,6 @@ def get_metrics():
 		pos = stats_pos[item]
 		metric_name = "node" + node_id + "_" + zone + "_" + item
 		values[metric_name] = metrics[pos]
-		
 
 	file.close
         # update cache
@@ -88,7 +88,7 @@ def get_metrics():
             'time': time.time(),
             'data': values
         }
-	
+
     return [METRICS]
 
 
@@ -98,7 +98,7 @@ def get_value(name):
     metrics = get_metrics()[0]
 
     prefix_length = len(NAME_PREFIX) + 1
-    name = name[prefix_length:] # remove prefix from name
+    name = name[prefix_length:]  # remove prefix from name
     try:
         result = metrics['data'][name]
     except StandardError:
@@ -112,6 +112,7 @@ def create_desc(skel, prop):
     for k,v in prop.iteritems():
         d[k] = v
     return d
+
 
 def metric_init(params):
     global descriptors, metric_map, Desc_Skel
@@ -127,7 +128,7 @@ def metric_init(params):
         'value_type'  : 'uint',
         'format'      : '%d',
         'units'       : 'segments',
-        'slope'       : 'both', # zero|positive|negative|both
+        'slope'       : 'both',  # zero|positive|negative|both
         'description' : 'XXX',
         'groups'      : 'mem_fragmentation',
         }
@@ -140,6 +141,7 @@ def metric_init(params):
 		    }))
 
     return descriptors
+
 
 def metric_cleanup():
     '''Clean up the metric module.'''

--- a/system/mem_stats/python_modules/mem_stats.py
+++ b/system/mem_stats/python_modules/mem_stats.py
@@ -16,7 +16,8 @@ import re
 
 meminfo_file = "/proc/meminfo"
 
-def metrics_handler(name):  
+
+def metrics_handler(name):
     try:
         file = open(meminfo_file, 'r')
 
@@ -33,14 +34,16 @@ def metrics_handler(name):
 		value = float(parts[1]) * 1024
 	    else:
                 value = parts[1]
-	
+
     return float(value)
+
 
 def create_desc(skel, prop):
     d = skel.copy()
     for k,v in prop.iteritems():
         d[k] = v
     return d
+
 
 def metric_init(params):
     global descriptors, metric_map, Desc_Skel
@@ -55,7 +58,7 @@ def metric_init(params):
         'value_type'  : 'float',
         'format'      : '%.0f',
         'units'       : 'XXX',
-        'slope'       : 'both', # zero|positive|negative|both
+        'slope'       : 'both',  # zero|positive|negative|both
         'description' : 'XXX',
         'groups'      : 'memory',
         }
@@ -349,12 +352,13 @@ def metric_init(params):
 
     # We need a metric_map that maps metric_name to the index in /proc/meminfo
     metric_map = {}
-    
+
     for d in descriptors:
 	metric_name = d['name']
         metric_map[metric_name] = { "name": d['orig_name'], "units": d['units'] }
-        
+
     return descriptors
+
 
 def metric_cleanup():
     '''Clean up the metric module.'''

--- a/system/vm_stats/python_modules/vm_stats.py
+++ b/system/vm_stats/python_modules/vm_stats.py
@@ -35,7 +35,7 @@ def get_metrics():
 
 	try:
 	    file = open(vminfo_file, 'r')
-    
+
 	except IOError:
 	    return 0
 
@@ -54,12 +54,13 @@ def get_metrics():
 
     return [METRICS, LAST_METRICS]
 
+
 def get_value(name):
     """Return a value for the requested metric"""
 
     metrics = get_metrics()[0]
 
-    name = name[len(NAME_PREFIX):] # remove prefix from name
+    name = name[len(NAME_PREFIX):]  # remove prefix from name
 
     try:
         result = metrics['data'][name]
@@ -75,7 +76,7 @@ def get_delta(name):
     # get metrics
     [curr_metrics, last_metrics] = get_metrics()
 
-    name = name[len(NAME_PREFIX):] # remove prefix from name
+    name = name[len(NAME_PREFIX):]  # remove prefix from name
 
     try:
       delta = (float(curr_metrics['data'][name]) - float(last_metrics['data'][name])) /(curr_metrics['time'] - last_metrics['time'])
@@ -83,7 +84,7 @@ def get_delta(name):
 	print name + " is less 0"
 	delta = 0
     except KeyError:
-      delta = 0.0      
+      delta = 0.0
 
     return delta
 
@@ -91,34 +92,35 @@ def get_delta(name):
 # Calculate VM efficiency
 # Works similar like sar -B 1
 # Calculated as pgsteal / pgscan, this is a metric of the efficiency of page reclaim. If  it  is  near  100%  then
-# almost  every  page coming off the tail of the inactive list is being reaped. If it gets too low (e.g. less than 30%)  
+# almost  every  page coming off the tail of the inactive list is being reaped. If it gets too low (e.g. less than 30%)
 # then the virtual memory is having some difficulty.  This field is displayed as zero if no pages  have  been
 # scanned during the interval of time
-def get_vmeff(name):  
+def get_vmeff(name):
     # get metrics
     [curr_metrics, last_metrics] = get_metrics()
-        
+
     try:
       pgscan_diff = float(curr_metrics['data']['pgscan_kswapd_normal']) - float(last_metrics['data']['pgscan_kswapd_normal'])
       # To avoid division by 0 errors check whether pgscan is 0
       if pgscan_diff == 0:
 	return 0.0
-	
+
       delta = 100 * (float(curr_metrics['data']['pgsteal_normal']) - float(last_metrics['data']['pgsteal_normal'])) / pgscan_diff
       if delta < 0:
         print name + " is less 0"
         delta = 0
     except KeyError:
-      delta = 0.0      
+      delta = 0.0
 
     return delta
-  
+
 
 def create_desc(skel, prop):
     d = skel.copy()
     for k,v in prop.iteritems():
         d[k] = v
     return d
+
 
 def metric_init(params):
     global descriptors, metric_map, Desc_Skel
@@ -132,7 +134,7 @@ def metric_init(params):
         'value_type'  : 'float',
         'format'      : '%.4f',
         'units'       : 'count',
-        'slope'       : 'both', # zero|positive|negative|both
+        'slope'       : 'both',  # zero|positive|negative|both
         'description' : 'XXX',
         'groups'      : 'memory_vm',
         }
@@ -715,6 +717,7 @@ def metric_init(params):
                 }))
 
     return descriptors
+
 
 def metric_cleanup():
     '''Clean up the metric module.'''

--- a/tokyo_tyrant/python_modules/tokyo_tyrant.py
+++ b/tokyo_tyrant/python_modules/tokyo_tyrant.py
@@ -75,7 +75,7 @@ def get_value(name):
 
     metrics = get_metrics()[0]
 
-    name = name[len(NAME_PREFIX):] # remove prefix from name
+    name = name[len(NAME_PREFIX):]  # remove prefix from name
     try:
         result = metrics['data'][name]
     except StandardError:
@@ -91,7 +91,7 @@ def get_delta(name):
     [curr_metrics, last_metrics] = get_metrics()
 
     # get delta
-    name = name[len(NAME_PREFIX):] # remove prefix from name
+    name = name[len(NAME_PREFIX):]  # remove prefix from name
     try:
         delta = (curr_metrics['data'][name] - last_metrics['data'][name])/(curr_metrics['time'] - last_metrics['time'])
         if delta < 0:

--- a/varnish/python_modules/varnish.py
+++ b/varnish/python_modules/varnish.py
@@ -40,6 +40,7 @@ METRICS = {
 LAST_METRICS = copy.deepcopy(METRICS)
 METRICS_CACHE_MAX = 5
 
+
 def create_desc(skel, prop):
     d = skel.copy()
     for k,v in prop.iteritems():
@@ -75,12 +76,13 @@ def get_metrics():
 
     return [METRICS, LAST_METRICS]
 
+
 def get_value(name):
     """Return a value for the requested metric"""
 
     metrics = get_metrics()[0]
 
-    name = name[len(NAME_PREFIX):] # remove prefix from name
+    name = name[len(NAME_PREFIX):]  # remove prefix from name
     try:
         result = metrics['data'][name]
     except StandardError:
@@ -96,7 +98,7 @@ def get_delta(name):
     [curr_metrics, last_metrics] = get_metrics()
 
     # get delta
-    name = name[len(NAME_PREFIX):] # remove prefix from name
+    name = name[len(NAME_PREFIX):]  # remove prefix from name
     try:
         delta = float(curr_metrics['data'][name] - last_metrics['data'][name])/(curr_metrics['time'] - last_metrics['time'])
         if delta < 0:
@@ -138,7 +140,7 @@ def metric_init(lparams):
         'value_type'  : 'float',
         'format'      : '%f',
         'units'       : 'XXX',
-        'slope'       : 'both', # zero|positive|negative|both
+        'slope'       : 'both',  # zero|positive|negative|both
         'description' : 'XXX',
         'groups'      : 'varnish',
         }
@@ -825,198 +827,195 @@ def metric_init(lparams):
                 }))
 
     ##############################################################################
-    
-    
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'backend_retry',
                 "call_back"  : get_delta,
                 "units"      : "retries/s",
                 "description": "Backend conn. retry",
                 }))
-    
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'dir_dns_cache_full',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "DNS director full dnscache",
                 }))
-    
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'dir_dns_failed',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "DNS director failed lookups",
                 }))
-    
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'dir_dns_hit',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "DNS director cached lookups hit",
                 }))
-    
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'dir_dns_lookups',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "DNS director lookups",
                 }))
-    
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'esi_warnings',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "ESI parse warnings (unlock)",
                 }))
-    
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'fetch_1xx',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "Fetch no body (1xx)",
                 }))
-    
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'fetch_204',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "Fetch no body (204)",
                 }))
-    
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'fetch_304',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "Fetch no body (304)",
                 }))
-    
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_ban',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "N total active bans",
                 }))
-    
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_ban_add',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "N new bans added",
                 }))
-    
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_ban_retire',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "N old bans deleted",
                 }))
-    
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_ban_obj_test',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "N objects tested",
                 }))
-    
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_ban_re_test',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "N regexps tested against",
                 }))
-    
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_ban_dups',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "N duplicate bans removed",
                 }))
-    
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_ban_add',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "N new bans added",
                 }))
-    
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_ban_dups',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "N duplicate bans removed",
                 }))
-    
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_ban_obj_test',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "N objects tested",
                 }))
-    
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_ban_re_test',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "N regexps tested against",
                 }))
-    
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_ban_retire',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "N old bans deleted",
                 }))
-    
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_gunzip',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "Gunzip operations",
                 }))
-    
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_gzip',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "Gzip operations",
                 }))
-    
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_vbc',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "N struct vbc",
                 }))
-    
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_waitinglist',
                 "call_back"  : get_delta,
                 "units"      : "/s",
                 "description": "N struct waitinglist",
                 }))
-    
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_wrk_lqueue',
                 "call_back"  : get_value,
                 "units"      : "",
                 "description": "work request queue length",
                 }))
-    
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'n_wrk_queued',
                 "call_back"  : get_value,
                 "units"      : "req",
                 "description": "N queued work requests",
                 }))
-    
+
     descriptors.append( create_desc(Desc_Skel, {
                 "name"       : NAME_PREFIX + 'vmods',
                 "call_back"  : get_value,
                 "units"      : "vmods",
                 "description": "Loaded VMODs",
                 }))
-
-
 
     return descriptors
 

--- a/xenstats/python_modules/xenstats.py
+++ b/xenstats/python_modules/xenstats.py
@@ -1,17 +1,17 @@
 #       xenstats.py
-#       
+#
 #       Copyright 2011 Marcos Amorim <marcosmamorim@gmail.com>
-#       
+#
 #       This program is free software; you can redistribute it and/or modify
 #       it under the terms of the GNU General Public License as published by
 #       the Free Software Foundation; either version 2 of the License, or
 #       (at your option) any later version.
-#       
+#
 #       This program is distributed in the hope that it will be useful,
 #       but WITHOUT ANY WARRANTY; without even the implied warranty of
 #       MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #       GNU General Public License for more details.
-#       
+#
 #       You should have received a copy of the GNU General Public License
 #       along with this program; if not, write to the Free Software
 #       Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
@@ -25,6 +25,7 @@ descriptors = list()
 conn        = libvirt.openReadOnly("xen:///")
 conn_info   = conn.getInfo()
 
+
 def xen_vms(name):
     '''Return number of virtual is running'''
     global conn
@@ -33,6 +34,7 @@ def xen_vms(name):
 
     return vm_count
 
+
 def xen_mem(name):
     '''Return node memory '''
     global conn
@@ -40,6 +42,7 @@ def xen_mem(name):
 
     # O xen retorna o valor da memoria em MB, vamos passar por KB
     return conn_info[1] * 1024
+
 
 def xen_cpu(name):
     '''Return numbers of CPU's'''
@@ -61,6 +64,7 @@ def xen_mem_use(name):
         vm_mem = vm_mem + info[2]
 
     return vm_mem
+
 
 def metric_init(params):
     global descriptors
@@ -112,6 +116,7 @@ def metric_init(params):
 
     return descriptors
 
+
 def metric_cleanup():
     '''Clean up the metric module.'''
     global conn
@@ -124,4 +129,3 @@ if __name__ == '__main__':
     for d in descriptors:
         v = d['call_back'](d['name'])
         print 'value for %s is %u' % (d['name'],  v)
-


### PR DESCRIPTION
.pep8 hold the configuration for the whole repository. It is used to
ignore some third party libraries (such as nvidia-ml-py) and some
to IGNORE some error codes:

  E203 whitespace before ':'

Issues fixed by this patch:

6       E223 tab before operator
15      E242 tab after ','
67      E261 at least two spaces before inline comment
3       E262 inline comment should start with '# '
211     W291 trailing whitespace
4       W292 no newline at end of file
302     W293 blank line contains whitespace
12      E301 expected 1 blank line, found 0
422     E302 expected 2 blank lines, found 1
x       E303 too many blank lines (2)
14      W391 blank line at end of file
