### PR TITLE
Update to handle Percona's show engine innodb status

### DIFF
--- a/mysqld/conf.d/mysql.pyconf
+++ b/mysqld/conf.d/mysql.pyconf
@@ -182,6 +182,10 @@ collection_group {
   }
 
   metric {
+    name = "mysql_innodb_buffer_pool_pages_bytes"
+  }
+
+  metric {
     name = "mysql_innodb_buffer_pool_pages_total"
   }
 

--- a/mysqld/python_modules/mysql.py
+++ b/mysqld/python_modules/mysql.py
@@ -999,6 +999,13 @@ def metric_init(params):
 				'units': 'writes',
 			},
 
+			innodb_buffer_pool_pages_bytes = {
+				'description': "The total size of buffer pool, in bytes",
+				'value_type':'uint',
+				'units': 'bytes',
+				'slope': 'both',
+			},
+
 			innodb_buffer_pool_pages_total = {
 				'description': "The total size of buffer pool, in pages",
 				'value_type':'uint',


### PR DESCRIPTION
I'm not sure if this is Percona specific, but this current python module could not handle this:

Buffer pool size        340272
Buffer pool size, bytes 5575016448  <--- this line would blow up the plugin

Also perhaps it is just Percona, but the SHOW /_!50000 ENGINE_/ INNODB STATUS output from Percona-Server-server-55-5.5.31-rel30.3.520.rhel6.x86_64 lists pool information as a total and then the individual pool values.  Because of this, the "totals" were getting clobbered by subsequent individual pool values for Buffer pool size, Free buffers, etc and what we (or at least I) want here is the total.  Look for 'Free buffers' in the below show engine innodb status output and I think it will be clear what I'm talking about (there are 17 matches):

**************************\* 1. row ***************************
  Type: InnoDB
  Name:
# Status:
#130618 22:49:17 INNODB MONITOR OUTPUT
## Per second averages calculated from the last 16 seconds
## BACKGROUND THREAD

srv_master_thread loops: 103561 1_second, 103480 sleeps, 10353 10_second, 64 background, 64 flush
## srv_master_thread log flush and writes: 105917
## SEMAPHORES

OS WAIT ARRAY INFO: reservation count 81750, signal count 87967
Mutex spin waits 1274177, rounds 3159416, OS waits 30147
RW-shared spins 68459, rounds 1401914, OS waits 33733
RW-excl spins 59196, rounds 1040704, OS waits 13894
## Spin rounds per wait: 2.48 mutex, 20.48 RW-shared, 17.58 RW-excl
## FILE I/O

I/O thread 0 state: waiting for completed aio requests (insert buffer thread)
I/O thread 1 state: waiting for completed aio requests (log thread)
I/O thread 2 state: waiting for completed aio requests (read thread)
I/O thread 3 state: waiting for completed aio requests (read thread)
I/O thread 4 state: waiting for completed aio requests (read thread)
I/O thread 5 state: waiting for completed aio requests (read thread)
I/O thread 6 state: waiting for completed aio requests (read thread)
I/O thread 7 state: waiting for completed aio requests (read thread)
I/O thread 8 state: waiting for completed aio requests (read thread)
I/O thread 9 state: waiting for completed aio requests (read thread)
I/O thread 10 state: waiting for completed aio requests (write thread)
I/O thread 11 state: waiting for completed aio requests (write thread)
I/O thread 12 state: waiting for completed aio requests (write thread)
I/O thread 13 state: waiting for completed aio requests (write thread)
I/O thread 14 state: waiting for completed aio requests (write thread)
I/O thread 15 state: waiting for completed aio requests (write thread)
I/O thread 16 state: waiting for completed aio requests (write thread)
I/O thread 17 state: waiting for completed aio requests (write thread)
Pending normal aio reads: 0 [0, 0, 0, 0, 0, 0, 0, 0] , aio writes: 0 [0, 0, 0, 0, 0, 0, 0, 0] ,
 ibuf aio reads: 0, log i/o's: 0, sync i/o's: 0
Pending flushes (fsync) log: 0; buffer pool: 0
1924 OS file reads, 1359822 OS file writes, 438969 OS fsyncs
## 0.00 reads/s, 0 avg bytes/read, 17.06 writes/s, 5.50 fsyncs/s
## INSERT BUFFER AND ADAPTIVE HASH INDEX

Ibuf: size 1, free list len 0, seg size 2, 0 merges
merged operations:
 insert 0, delete mark 0, delete 0
discarded operations:
 insert 0, delete mark 0, delete 0
Hash table size 11033279, node heap has 14 buffer(s)
## 339.73 hash searches/s, 16.25 non-hash searches/s
## LOG

Log sequence number 985519773
Log flushed up to   985519773
Last checkpoint at  985192071
Max checkpoint age    2608481527
Checkpoint age target 2526966480
Modified age          327702
Checkpoint age        327702
0 pending log writes, 0 pending chkp writes
## 118003 log i/o's done, 1.19 log i/o's/second
## BUFFER POOL AND MEMORY

Total memory allocated 5725224960; in additional pool allocated 0
Total memory allocated by read views 3808
Internal hash tables (constant factor + variable factor)
    Adaptive hash index 88499824        (88266232 + 233592)
    Page hash           345608 (buffer pool 0 only)
    Dictionary cache    27051053        (22068016 + 4983037)
    File system         338848  (82672 + 256176)
    Lock system         13800568        (13793048 + 7520)
    Recovery system     0       (0 + 0)
Dictionary memory allocated 4983037
Buffer pool size        340272
Buffer pool size, bytes 5575016448
Free buffers            335557
Database pages          4701
Old database pages      0
Modified db pages       207
Pending reads 0
Pending writes: LRU 0, flush list 0, single page 0
Pages made young 0, not young 0
0.00 youngs/s, 0.00 non-youngs/s
Pages read 1654, created 3047, written 1086766
0.00 reads/s, 0.00 creates/s, 13.87 writes/s
Buffer pool hit rate 1000 / 1000, young-making rate 0 / 1000 not 0 / 1000
Pages read ahead 0.00/s, evicted without access 0.00/s, Random read ahead 0.00/s
LRU len: 4701, unzip_LRU len: 0
## I/O sum[0]:cur[0], unzip sum[0]:cur[0]
## INDIVIDUAL BUFFER POOL INFO

---BUFFER POOL 0
Buffer pool size        21267
Buffer pool size, bytes 348438528
Free buffers            20994
Database pages          271
Old database pages      0
Modified db pages       15
Pending reads 0
Pending writes: LRU 0, flush list 0, single page 0
Pages made young 0, not young 0
0.00 youngs/s, 0.00 non-youngs/s
Pages read 98, created 173, written 154156
0.00 reads/s, 0.00 creates/s, 1.87 writes/s
Buffer pool hit rate 1000 / 1000, young-making rate 0 / 1000 not 0 / 1000
Pages read ahead 0.00/s, evicted without access 0.00/s, Random read ahead 0.00/s
LRU len: 271, unzip_LRU len: 0
I/O sum[0]:cur[0], unzip sum[0]:cur[0]
---BUFFER POOL 1
Buffer pool size        21267
Buffer pool size, bytes 348438528
Free buffers            21025
Database pages          241
Old database pages      0
Modified db pages       0
Pending reads 0
Pending writes: LRU 0, flush list 0, single page 0
Pages made young 0, not young 0
0.00 youngs/s, 0.00 non-youngs/s
Pages read 65, created 176, written 74
0.00 reads/s, 0.00 creates/s, 0.00 writes/s
Buffer pool hit rate 1000 / 1000, young-making rate 0 / 1000 not 0 / 1000
Pages read ahead 0.00/s, evicted without access 0.00/s, Random read ahead 0.00/s
LRU len: 241, unzip_LRU len: 0
I/O sum[0]:cur[0], unzip sum[0]:cur[0]
---BUFFER POOL 2
Buffer pool size        21267
Buffer pool size, bytes 348438528
Free buffers            21005
Database pages          261
Old database pages      0
Modified db pages       0
Pending reads 0
Pending writes: LRU 0, flush list 0, single page 0
Pages made young 0, not young 0
0.00 youngs/s, 0.00 non-youngs/s
Pages read 86, created 175, written 179
0.00 reads/s, 0.00 creates/s, 0.00 writes/s
Buffer pool hit rate 1000 / 1000, young-making rate 0 / 1000 not 0 / 1000
Pages read ahead 0.00/s, evicted without access 0.00/s, Random read ahead 0.00/s
LRU len: 261, unzip_LRU len: 0
I/O sum[0]:cur[0], unzip sum[0]:cur[0]
---BUFFER POOL 3
Buffer pool size        21267
Buffer pool size, bytes 348438528
Free buffers            20941
Database pages          325
Old database pages      0
Modified db pages       52
Pending reads 0
Pending writes: LRU 0, flush list 0, single page 0
Pages made young 0, not young 0
0.00 youngs/s, 0.00 non-youngs/s
Pages read 148, created 177, written 155162
0.00 reads/s, 0.00 creates/s, 1.87 writes/s
Buffer pool hit rate 1000 / 1000, young-making rate 0 / 1000 not 0 / 1000
Pages read ahead 0.00/s, evicted without access 0.00/s, Random read ahead 0.00/s
LRU len: 325, unzip_LRU len: 0
I/O sum[0]:cur[0], unzip sum[0]:cur[0]
---BUFFER POOL 4
Buffer pool size        21267
Buffer pool size, bytes 348438528
Free buffers            20951
Database pages          316
Old database pages      0
Modified db pages       42
Pending reads 0
Pending writes: LRU 0, flush list 0, single page 0
Pages made young 0, not young 0
0.00 youngs/s, 0.00 non-youngs/s
Pages read 139, created 177, written 154841
0.00 reads/s, 0.00 creates/s, 1.87 writes/s
Buffer pool hit rate 1000 / 1000, young-making rate 0 / 1000 not 0 / 1000
Pages read ahead 0.00/s, evicted without access 0.00/s, Random read ahead 0.00/s
LRU len: 316, unzip_LRU len: 0
I/O sum[0]:cur[0], unzip sum[0]:cur[0]
---BUFFER POOL 5
Buffer pool size        21267
Buffer pool size, bytes 348438528
Free buffers            20951
Database pages          316
Old database pages      0
Modified db pages       2
Pending reads 0
Pending writes: LRU 0, flush list 0, single page 0
Pages made young 0, not young 0
0.00 youngs/s, 0.00 non-youngs/s
Pages read 130, created 186, written 55600
0.00 reads/s, 0.00 creates/s, 0.62 writes/s
Buffer pool hit rate 1000 / 1000, young-making rate 0 / 1000 not 0 / 1000
Pages read ahead 0.00/s, evicted without access 0.00/s, Random read ahead 0.00/s
LRU len: 316, unzip_LRU len: 0
I/O sum[0]:cur[0], unzip sum[0]:cur[0]
---BUFFER POOL 6
Buffer pool size        21267
Buffer pool size, bytes 348438528
Free buffers            20948
Database pages          319
Old database pages      0
Modified db pages       2
Pending reads 0
Pending writes: LRU 0, flush list 0, single page 0
Pages made young 0, not young 0
0.00 youngs/s, 0.00 non-youngs/s
Pages read 123, created 196, written 11031
0.00 reads/s, 0.00 creates/s, 0.19 writes/s
Buffer pool hit rate 1000 / 1000, young-making rate 0 / 1000 not 0 / 1000
Pages read ahead 0.00/s, evicted without access 0.00/s, Random read ahead 0.00/s
LRU len: 319, unzip_LRU len: 0
I/O sum[0]:cur[0], unzip sum[0]:cur[0]
---BUFFER POOL 7
Buffer pool size        21267
Buffer pool size, bytes 348438528
Free buffers            20935
Database pages          331
Old database pages      0
Modified db pages       10
Pending reads 0
Pending writes: LRU 0, flush list 0, single page 0
Pages made young 0, not young 0
0.00 youngs/s, 0.00 non-youngs/s
Pages read 126, created 205, written 108464
0.00 reads/s, 0.00 creates/s, 1.81 writes/s
Buffer pool hit rate 1000 / 1000, young-making rate 0 / 1000 not 0 / 1000
Pages read ahead 0.00/s, evicted without access 0.00/s, Random read ahead 0.00/s
LRU len: 331, unzip_LRU len: 0
I/O sum[0]:cur[0], unzip sum[0]:cur[0]
---BUFFER POOL 8
Buffer pool size        21267
Buffer pool size, bytes 348438528
Free buffers            20907
Database pages          359
Old database pages      0
Modified db pages       47
Pending reads 0
Pending writes: LRU 0, flush list 0, single page 0
Pages made young 0, not young 0
0.00 youngs/s, 0.00 non-youngs/s
Pages read 156, created 203, written 150977
0.00 reads/s, 0.00 creates/s, 1.87 writes/s
Buffer pool hit rate 1000 / 1000, young-making rate 0 / 1000 not 0 / 1000
Pages read ahead 0.00/s, evicted without access 0.00/s, Random read ahead 0.00/s
LRU len: 359, unzip_LRU len: 0
I/O sum[0]:cur[0], unzip sum[0]:cur[0]
---BUFFER POOL 9
Buffer pool size        21267
Buffer pool size, bytes 348438528
Free buffers            20934
Database pages          332
Old database pages      0
Modified db pages       26
Pending reads 0
Pending writes: LRU 0, flush list 0, single page 0
Pages made young 0, not young 0
0.00 youngs/s, 0.00 non-youngs/s
Pages read 132, created 200, written 149708
0.00 reads/s, 0.00 creates/s, 1.87 writes/s
Buffer pool hit rate 1000 / 1000, young-making rate 0 / 1000 not 0 / 1000
Pages read ahead 0.00/s, evicted without access 0.00/s, Random read ahead 0.00/s
LRU len: 332, unzip_LRU len: 0
I/O sum[0]:cur[0], unzip sum[0]:cur[0]
---BUFFER POOL 10
Buffer pool size        21267
Buffer pool size, bytes 348438528
Free buffers            20930
Database pages          336
Old database pages      0
Modified db pages       11
Pending reads 0
Pending writes: LRU 0, flush list 0, single page 0
Pages made young 0, not young 0
0.00 youngs/s, 0.00 non-youngs/s
Pages read 77, created 259, written 146067
0.00 reads/s, 0.00 creates/s, 1.87 writes/s
Buffer pool hit rate 1000 / 1000, young-making rate 0 / 1000 not 0 / 1000
Pages read ahead 0.00/s, evicted without access 0.00/s, Random read ahead 0.00/s
LRU len: 336, unzip_LRU len: 0
I/O sum[0]:cur[0], unzip sum[0]:cur[0]
---BUFFER POOL 11
Buffer pool size        21267
Buffer pool size, bytes 348438528
Free buffers            20979
Database pages          287
Old database pages      0
Modified db pages       0
Pending reads 0
Pending writes: LRU 0, flush list 0, single page 0
Pages made young 0, not young 0
0.00 youngs/s, 0.00 non-youngs/s
Pages read 87, created 200, written 50
0.00 reads/s, 0.00 creates/s, 0.00 writes/s
Buffer pool hit rate 1000 / 1000, young-making rate 0 / 1000 not 0 / 1000
Pages read ahead 0.00/s, evicted without access 0.00/s, Random read ahead 0.00/s
LRU len: 287, unzip_LRU len: 0
I/O sum[0]:cur[0], unzip sum[0]:cur[0]
---BUFFER POOL 12
Buffer pool size        21267
Buffer pool size, bytes 348438528
Free buffers            21013
Database pages          254
Old database pages      0
Modified db pages       0
Pending reads 0
Pending writes: LRU 0, flush list 0, single page 0
Pages made young 0, not young 0
0.00 youngs/s, 0.00 non-youngs/s
Pages read 71, created 183, written 168
0.00 reads/s, 0.00 creates/s, 0.00 writes/s
Buffer pool hit rate 1000 / 1000, young-making rate 0 / 1000 not 0 / 1000
Pages read ahead 0.00/s, evicted without access 0.00/s, Random read ahead 0.00/s
LRU len: 254, unzip_LRU len: 0
I/O sum[0]:cur[0], unzip sum[0]:cur[0]
---BUFFER POOL 13
Buffer pool size        21267
Buffer pool size, bytes 348438528
Free buffers            21031
Database pages          235
Old database pages      0
Modified db pages       0
Pending reads 0
Pending writes: LRU 0, flush list 0, single page 0
Pages made young 0, not young 0
0.00 youngs/s, 0.00 non-youngs/s
Pages read 49, created 186, written 40
0.00 reads/s, 0.00 creates/s, 0.00 writes/s
Buffer pool hit rate 1000 / 1000, young-making rate 0 / 1000 not 0 / 1000
Pages read ahead 0.00/s, evicted without access 0.00/s, Random read ahead 0.00/s
LRU len: 235, unzip_LRU len: 0
I/O sum[0]:cur[0], unzip sum[0]:cur[0]
---BUFFER POOL 14
Buffer pool size        21267
Buffer pool size, bytes 348438528
Free buffers            21004
Database pages          262
Old database pages      0
Modified db pages       0
Pending reads 0
Pending writes: LRU 0, flush list 0, single page 0
Pages made young 0, not young 0
0.00 youngs/s, 0.00 non-youngs/s
Pages read 88, created 174, written 213
0.00 reads/s, 0.00 creates/s, 0.00 writes/s
Buffer pool hit rate 1000 / 1000, young-making rate 0 / 1000 not 0 / 1000
Pages read ahead 0.00/s, evicted without access 0.00/s, Random read ahead 0.00/s
LRU len: 262, unzip_LRU len: 0
I/O sum[0]:cur[0], unzip sum[0]:cur[0]
---BUFFER POOL 15
Buffer pool size        21267
Buffer pool size, bytes 348438528
Free buffers            21009
Database pages          256
Old database pages      0
Modified db pages       0
Pending reads 0
Pending writes: LRU 0, flush list 0, single page 0
Pages made young 0, not young 0
0.00 youngs/s, 0.00 non-youngs/s
Pages read 79, created 177, written 36
0.00 reads/s, 0.00 creates/s, 0.00 writes/s
Buffer pool hit rate 1000 / 1000, young-making rate 0 / 1000 not 0 / 1000
Pages read ahead 0.00/s, evicted without access 0.00/s, Random read ahead 0.00/s
LRU len: 256, unzip_LRU len: 0
## I/O sum[0]:cur[0], unzip sum[0]:cur[0]
## ROW OPERATIONS

0 queries inside InnoDB, 0 queries in queue
1 read views open inside InnoDB
0 transactions active inside InnoDB
0 out of 1000 descriptors used
---OLDEST VIEW---
Normal read view
Read view low limit trx n:o 9C7629
Read view up limit trx id 9C7629
Read view low limit trx id 9C7629
## Read view individually stored trx ids:

Main thread process no. 7477, id 139731153004288, state: flushing log
Number of rows inserted 6832, updated 1989039, deleted 7105, read 7241721
## 0.00 inserts/s, 20.87 updates/s, 0.00 deletes/s, 415.35 reads/s
## TRANSACTIONS

Trx id counter 9C7629
Purge done for trx's n:o < 9C7629 undo n:o < 0
History list length 4023
LIST OF TRANSACTIONS FOR EACH SESSION:
---TRANSACTION 0, not started
MySQL thread id 1314, OS thread handle 0x7f15b0609700, query id 18351790 localhost root
SHOW /_!50000 ENGINE_/ INNODB STATUS
---TRANSACTION 9C65C3, not started
MySQL thread id 1306, OS thread handle 0x7f17a43df700, query id 18344231 localhost 127.0.0.1 controller
---TRANSACTION 9C65C2, not started
MySQL thread id 1305, OS thread handle 0x7f15b06cc700, query id 18344230 localhost 127.0.0.1 controller
---TRANSACTION 9C690C, not started
MySQL thread id 1303, OS thread handle 0x7f15b064a700, query id 18345749 localhost 127.0.0.1 controller
---TRANSACTION 9C74F5, not started
MySQL thread id 1302, OS thread handle 0x7f17a4092700, query id 18351250 localhost 127.0.0.1 controller
---TRANSACTION 9C74F0, not started
MySQL thread id 1294, OS thread handle 0x7f15b07d0700, query id 18351242 localhost 127.0.0.1 controller
---TRANSACTION 9C75E3, not started
MySQL thread id 1293, OS thread handle 0x7f17a4259700, query id 18351667 localhost 127.0.0.1 controller
---TRANSACTION 9C75ED, not started
MySQL thread id 1281, OS thread handle 0x7f15b04c4700, query id 18351686 localhost 127.0.0.1 controller
---TRANSACTION 9C75E4, not started
MySQL thread id 1280, OS thread handle 0x7f17a439e700, query id 18351673 localhost 127.0.0.1 controller
---TRANSACTION 9C75F1, not started
MySQL thread id 1273, OS thread handle 0x7f17a4051700, query id 18351688 localhost 127.0.0.1 controller
---TRANSACTION 9C761B, not started
MySQL thread id 1272, OS thread handle 0x7f15b070d700, query id 18351769 localhost 127.0.0.1 controller
---TRANSACTION 9C761A, not started
MySQL thread id 1266, OS thread handle 0x7f15b078f700, query id 18351760 localhost 127.0.0.1 controller
---TRANSACTION 9C7626, not started
MySQL thread id 1265, OS thread handle 0x7f15b05c8700, query id 18351786 localhost 127.0.0.1 controller
---TRANSACTION 9C7622, not started
MySQL thread id 1259, OS thread handle 0x7f17a431c700, query id 18351782 localhost 127.0.0.1 controller
---TRANSACTION 9C7625, not started
MySQL thread id 1258, OS thread handle 0x7f17a4218700, query id 18351788 localhost 127.0.0.1 controller
---TRANSACTION 9C6CDB, not started
MySQL thread id 329, OS thread handle 0x7f17a40d3700, query id 18347515 localhost 127.0.0.1 controller
---TRANSACTION 9C6CD8, not started
MySQL thread id 333, OS thread handle 0x7f17a4114700, query id 18347508 localhost 127.0.0.1 controller
---TRANSACTION 9C6CDD, not started
MySQL thread id 332, OS thread handle 0x7f15b074e700, query id 18347520 localhost 127.0.0.1 controller
---TRANSACTION 9C6CE3, not started
MySQL thread id 331, OS thread handle 0x7f15b068b700, query id 18347531 localhost 127.0.0.1 controller
---TRANSACTION 9C6CD7, not started
## MySQL thread id 330, OS thread handle 0x7f17a435d700, query id 18347511 localhost 127.0.0.1 controller
# END OF INNODB MONITOR OUTPUT
