### PR TITLE
Update multi_interface.py to not bail out on metric_cleanup function

### DIFF
--- a/network/multi_interface/python_modules/multi_interface.py
+++ b/network/multi_interface/python_modules/multi_interface.py
@@ -108,6 +108,10 @@ def metric_init(params):
 
     return descriptors
 
+def metric_cleanup():
+    '''Clean up the metric module.'''
+    pass
+    
 def get_interfaces(watch_interfaces, excluded_interfaces):
 	global INTERFACES
         


### PR DESCRIPTION
Error:

$ sudo gmond -m
Unable to find the metric information for 'procs_blocked'. Possible that the module has not been loaded.

Unable to find the metric information for 'procs_created'. Possible that the module has not been loaded.

Unable to find any metric information for 'softirq_(.+)'. Possible that a module has not been loaded.

AttributeError: 'module' object has no attribute 'metric_cleanup'

Further checking, it revealed that multi_interface.py does not metric_cleanup function defined.
