### PR TITLE
Added support for NFS v4.

### DIFF
--- a/nfsstats/conf.d/nfsstats.pyconf
+++ b/nfsstats/conf.d/nfsstats.pyconf
@@ -184,4 +184,432 @@ collection_group {
     name = "nfsd_v3_commit"
     title = "NFSD v3 commit"
   }
+  metric {
+    name = "nfs_v4_total"
+    title = "NFS v4 total"
+  }
+  metric {
+    name = "nfs_v4_read"
+    title = "NFS v4 read"
+  }
+  metric {
+    name = "nfs_v4_write"
+    title = "NFS v4 write"
+  }
+  metric {
+    name = "nfs_v4_commit"
+    title = "NFS v4 commit"
+  }
+  metric {
+    name = "nfs_v4_open"
+    title = "NFS v4 open"
+  }
+  metric {
+    name = "nfs_v4_open_conf"
+    title = "NFS v4 open_conf"
+  }
+  metric {
+    name = "nfs_v4_open_noat"
+    title = "NFS v4 open_noat"
+  }
+  metric {
+    name = "nfs_v4_open_dgrd"
+    title = "NFS v4 open_dgrd"
+  }
+  metric {
+    name = "nfs_v4_close"
+    title = "NFS v4 close"
+  }
+  metric {
+    name = "nfs_v4_setattr"
+    title = "NFS v4 setattr"
+  }
+  metric {
+    name = "nfs_v4_renew"
+    title = "NFS v4 renew"
+  }
+  metric {
+    name = "nfs_v4_setclntid"
+    title = "NFS v4 setclntid"
+  }
+  metric {
+    name = "nfs_v4_confirm"
+    title = "NFS v4 confirm"
+  }
+  metric {
+    name = "nfs_v4_lock"
+    title = "NFS v4 lock"
+  }
+  metric {
+    name = "nfs_v4_lockt"
+    title = "NFS v4 lockt"
+  }
+  metric {
+    name = "nfs_v4_locku"
+    title = "NFS v4 locku"
+  }
+  metric {
+    name = "nfs_v4_access"
+    title = "NFS v4 access"
+  }
+  metric {
+    name = "nfs_v4_getattr"
+    title = "NFS v4 getattr"
+  }
+  metric {
+    name = "nfs_v4_lookup"
+    title = "NFS v4 lookup"
+  }
+  metric {
+    name = "nfs_v4_lookup_root"
+    title = "NFS v4 lookup_root"
+  }
+  metric {
+    name = "nfs_v4_remove"
+    title = "NFS v4 remove"
+  }
+  metric {
+    name = "nfs_v4_rename"
+    title = "NFS v4 rename"
+  }
+  metric {
+    name = "nfs_v4_link"
+    title = "NFS v4 link"
+  }
+  metric {
+    name = "nfs_v4_symlink"
+    title = "NFS v4 symlink"
+  }
+  metric {
+    name = "nfs_v4_create"
+    title = "NFS v4 create"
+  }
+  metric {
+    name = "nfs_v4_pathconf"
+    title = "NFS v4 pathconf"
+  }
+  metric {
+    name = "nfs_v4_statfs"
+    title = "NFS v4 statfs"
+  }
+  metric {
+    name = "nfs_v4_readlink"
+    title = "NFS v4 readlink"
+  }
+  metric {
+    name = "nfs_v4_readdir"
+    title = "NFS v4 readdir"
+  }
+  metric {
+    name = "nfs_v4_server_caps"
+    title = "NFS v4 server_caps"
+  }
+  metric {
+    name = "nfs_v4_delegreturn"
+    title = "NFS v4 delegreturn"
+  }
+  metric {
+    name = "nfs_v4_getacl"
+    title = "NFS v4 getacl"
+  }
+  metric {
+    name = "nfs_v4_setacl"
+    title = "NFS v4 setacl"
+  }
+  metric {
+    name = "nfs_v4_fs_locations"
+    title = "NFS v4 fs_locations"
+  }
+  metric {
+    name = "nfs_v4_rel_lkowner"
+    title = "NFS v4 rel_lkowner"
+  }
+  metric {
+    name = "nfs_v4_secinfo"
+    title = "NFS v4 secinfo"
+  }
+  metric {
+    name = "nfs_v4_exchange_id"
+    title = "NFS v4 exchange_id"
+  }
+  metric {
+    name = "nfs_v4_create_ses"
+    title = "NFS v4 create_ses"
+  }
+  metric {
+    name = "nfs_v4_destroy_ses"
+    title = "NFS v4 destroy_ses"
+  }
+  metric {
+    name = "nfs_v4_sequence"
+    title = "NFS v4 sequence"
+  }
+  metric {
+    name = "nfs_v4_get_lease_t"
+    title = "NFS v4 get_lease_t"
+  }
+  metric {
+    name = "nfs_v4_reclaim_comp"
+    title = "NFS v4 reclaim_comp"
+  }
+  metric {
+    name = "nfs_v4_layoutget"
+    title = "NFS v4 layoutget"
+  }
+  metric {
+    name = "nfs_v4_getdevinfo"
+    title = "NFS v4 getdevinfo"
+  }
+  metric {
+    name = "nfs_v4_layoutcommit"
+    title = "NFS v4 layoutcommit"
+  }
+  metric {
+    name = "nfs_v4_layoutreturn"
+    title = "NFS v4 layoutreturn"
+  }
+  metric {
+    name = "nfs_v4_getdevlist"
+    title = "NFS v4 getdevlist"
+  }
+  metric {
+    name = "nfsd_v4_total"
+    title = "NFSD v4 total"
+  }
+  metric {
+    name = "nfsd_v4_op0-unused"
+    title = "NFSD v4 op0-unused"
+  }
+  metric {
+    name = "nfsd_v4_op1-unused"
+    title = "NFSD v4 op1-unused"
+  }
+  metric {
+    name = "nfsd_v4_op2-future"
+    title = "NFSD v4 op2-future"
+  }
+  metric {
+    name = "nfsd_v4_access"
+    title = "NFSD v4 access"
+  }
+  metric {
+    name = "nfsd_v4_close"
+    title = "NFSD v4 close"
+  }
+  metric {
+    name = "nfsd_v4_commit"
+    title = "NFSD v4 commit"
+  }
+  metric {
+    name = "nfsd_v4_create"
+    title = "NFSD v4 create"
+  }
+  metric {
+    name = "nfsd_v4_delegpurge"
+    title = "NFSD v4 delegpurge"
+  }
+  metric {
+    name = "nfsd_v4_delegreturn"
+    title = "NFSD v4 delegreturn"
+  }
+  metric {
+    name = "nfsd_v4_getattr"
+    title = "NFSD v4 getattr"
+  }
+  metric {
+    name = "nfsd_v4_getfh"
+    title = "NFSD v4 getfh"
+  }
+  metric {
+    name = "nfsd_v4_link"
+    title = "NFSD v4 link"
+  }
+  metric {
+    name = "nfsd_v4_lock"
+    title = "NFSD v4 lock"
+  }
+  metric {
+    name = "nfsd_v4_lockt"
+    title = "NFSD v4 lockt"
+  }
+  metric {
+    name = "nfsd_v4_locku"
+    title = "NFSD v4 locku"
+  }
+  metric {
+    name = "nfsd_v4_lookup"
+    title = "NFSD v4 lookup"
+  }
+  metric {
+    name = "nfsd_v4_lookup_root"
+    title = "NFSD v4 lookup_root"
+  }
+  metric {
+    name = "nfsd_v4_nverify"
+    title = "NFSD v4 nverify"
+  }
+  metric {
+    name = "nfsd_v4_open"
+    title = "NFSD v4 open"
+  }
+  metric {
+    name = "nfsd_v4_openattr"
+    title = "NFSD v4 openattr"
+  }
+  metric {
+    name = "nfsd_v4_open_conf"
+    title = "NFSD v4 open_conf"
+  }
+  metric {
+    name = "nfsd_v4_open_dgrd"
+    title = "NFSD v4 open_dgrd"
+  }
+  metric {
+    name = "nfsd_v4_putfh"
+    title = "NFSD v4 putfh"
+  }
+  metric {
+    name = "nfsd_v4_putpubfh"
+    title = "NFSD v4 putpubfh"
+  }
+  metric {
+    name = "nfsd_v4_putrootfh"
+    title = "NFSD v4 putrootfh"
+  }
+  metric {
+    name = "nfsd_v4_read"
+    title = "NFSD v4 read"
+  }
+  metric {
+    name = "nfsd_v4_readdir"
+    title = "NFSD v4 readdir"
+  }
+  metric {
+    name = "nfsd_v4_readlink"
+    title = "NFSD v4 readlink"
+  }
+  metric {
+    name = "nfsd_v4_remove"
+    title = "NFSD v4 remove"
+  }
+  metric {
+    name = "nfsd_v4_rename"
+    title = "NFSD v4 rename"
+  }
+  metric {
+    name = "nfsd_v4_renew"
+    title = "NFSD v4 renew"
+  }
+  metric {
+    name = "nfsd_v4_restorefh"
+    title = "NFSD v4 restorefh"
+  }
+  metric {
+    name = "nfsd_v4_savefh"
+    title = "NFSD v4 savefh"
+  }
+  metric {
+    name = "nfsd_v4_secinfo"
+    title = "NFSD v4 secinfo"
+  }
+  metric {
+    name = "nfsd_v4_setattr"
+    title = "NFSD v4 setattr"
+  }
+  metric {
+    name = "nfsd_v4_setcltid"
+    title = "NFSD v4 setcltid"
+  }
+  metric {
+    name = "nfsd_v4_setcltidconf"
+    title = "NFSD v4 setcltidconf"
+  }
+  metric {
+    name = "nfsd_v4_verify"
+    title = "NFSD v4 verify"
+  }
+  metric {
+    name = "nfsd_v4_write"
+    title = "NFSD v4 write"
+  }
+  metric {
+    name = "nfsd_v4_rellockowner"
+    title = "NFSD v4 rellockowner"
+  }
+  metric {
+    name = "nfsd_v4_bc_ctl"
+    title = "NFSD v4 bc_ctl"
+  }
+  metric {
+    name = "nfsd_v4_bind_conn"
+    title = "NFSD v4 bind_conn"
+  }
+  metric {
+    name = "nfsd_v4_exchange_id"
+    title = "NFSD v4 exchange_id"
+  }
+  metric {
+    name = "nfsd_v4_create_ses"
+    title = "NFSD v4 create_ses"
+  }
+  metric {
+    name = "nfsd_v4_destroy_ses"
+    title = "NFSD v4 destroy_ses"
+  }
+  metric {
+    name = "nfsd_v4_free_stateid"
+    title = "NFSD v4 free_stateid"
+  }
+  metric {
+    name = "nfsd_v4_getdirdeleg"
+    title = "NFSD v4 getdirdeleg"
+  }
+  metric {
+    name = "nfsd_v4_getdevinfo"
+    title = "NFSD v4 getdevinfo"
+  }
+  metric {
+    name = "nfsd_v4_getdevlist"
+    title = "NFSD v4 getdevlist"
+  }
+  metric {
+    name = "nfsd_v4_layoutcommit"
+    title = "NFSD v4 layoutcommit"
+  }
+  metric {
+    name = "nfsd_v4_layoutget"
+    title = "NFSD v4 layoutget"
+  }
+  metric {
+    name = "nfsd_v4_layoutreturn"
+    title = "NFSD v4 layoutreturn"
+  }
+  metric {
+    name = "nfsd_v4_secinfononam"
+    title = "NFSD v4 secinfononam"
+  }
+  metric {
+    name = "nfsd_v4_sequence"
+    title = "NFSD v4 sequence"
+  }
+  metric {
+    name = "nfsd_v4_set_ssv"
+    title = "NFSD v4 set_ssv"
+  }
+  metric {
+    name = "nfsd_v4_test_stateid"
+    title = "NFSD v4 test_stateid"
+  }
+  metric {
+    name = "nfsd_v4_want_deleg"
+    title = "NFSD v4 want_deleg"
+  }
+  metric {
+    name = "nfsd_v4_destroy_clid"
+    title = "NFSD v4 destroy_clid"
+  }
+  metric {
+    name = "nfsd_v4_reclaim_comp"
+    title = "NFSD v4 reclaim_comp"
+  }
 }

--- a/nfsstats/python_modules/nfsstats.py
+++ b/nfsstats/python_modules/nfsstats.py
@@ -8,10 +8,10 @@ import syslog
 import sys
 import string
 
-def test_proc3( p_file ):
-
+def test_proc( p_file, p_string ):
+    global p_match
     """
-    Check if <p_file> contains keyword 'proc3'
+    Check if <p_file> contains keyword <p_string> e.g. proc3, proc4
     """
 
     p_fd = open( p_file )
@@ -20,9 +20,9 @@ def test_proc3( p_file ):
 
     p_fd.close()
 
-    m = re.search(".*proc3.*", p_contents, flags=re.MULTILINE)
+    p_match = re.search(".*" + p_string + "\s.*", p_contents, flags=re.MULTILINE)
 
-    if not m:
+    if not p_match:
         return False
     else:
         return True
@@ -34,7 +34,7 @@ old_values = { }
 configtable = [
     {
         'group': 'nfs_client',
-        'tests': [ 'stat.S_ISREG(os.stat("/proc/net/rpc/nfs").st_mode)', 'test_proc3("/proc/net/rpc/nfs")' ],
+        'tests': [ 'stat.S_ISREG(os.stat("/proc/net/rpc/nfs").st_mode)', 'test_proc("/proc/net/rpc/nfs", "proc3")' ],
         'prefix': 'nfs_v3_',
         #  The next 4 lines can be at the 'group' level or the 'name' level
         'file': '/proc/net/rpc/nfs',
@@ -67,8 +67,67 @@ configtable = [
         }
     },
     {
+        'group': 'nfs_client_v4',
+        'tests': [ 'stat.S_ISREG(os.stat("/proc/net/rpc/nfs").st_mode)', 'test_proc("/proc/net/rpc/nfs", "proc4")' ],
+        'prefix': 'nfs_v4_',
+        #  The next 4 lines can be at the 'group' level or the 'name' level
+        'file': '/proc/net/rpc/nfs',
+        'value_type': 'float',
+        'units': 'calls/sec',
+        'format': '%f',
+        'names': {
+            'total':        { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){2}(\d+.*\d)\n" },
+            'read':         { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){2}(\S*)" },
+            'write':        { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){3}(\S*)" },
+            'commit':       { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){4}(\S*)" },
+            'open':         { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){5}(\S*)" },
+            'open_conf':    { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){6}(\S*)" },
+            'open_noat':    { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){7}(\S*)" },
+            'open_dgrd':    { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){8}(\S*)" },
+            'close':        { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){9}(\S*)" },
+            'setattr':      { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){10}(\S*)" },
+            'renew':        { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){11}(\S*)" },
+            'setclntid':    { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){12}(\S*)" },
+            'confirm':      { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){13}(\S*)" },
+            'lock':         { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){14}(\S*)" },
+            'lockt':        { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){15}(\S*)" },
+            'locku':        { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){16}(\S*)" },
+            'access':       { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){17}(\S*)" },
+            'getattr':      { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){18}(\S*)" },
+            'lookup':       { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){19}(\S*)" },
+            'lookup_root':  { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){20}(\S*)" },
+            'remove':       { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){21}(\S*)" },
+            'rename':       { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){22}(\S*)" },
+            'link':         { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){23}(\S*)" },
+            'symlink':      { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){24}(\S*)" },
+            'create':       { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){25}(\S*)" },
+            'pathconf':     { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){26}(\S*)" },
+            'statfs':       { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){27}(\S*)" },
+            'readlink':     { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){28}(\S*)" },
+            'readdir':      { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){29}(\S*)" },
+            'server_caps':  { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){30}(\S*)" },
+            'delegreturn':  { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){31}(\S*)" },
+            'getacl':       { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){32}(\S*)" },
+            'setacl':       { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){33}(\S*)" },
+            'fs_locations': { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){34}(\S*)" },
+            'rel_lkowner':  { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){35}(\S*)" },
+            'secinfo':      { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){36}(\S*)" },
+            'exchange_id':  { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){37}(\S*)" },
+            'create_ses':   { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){38}(\S*)" },
+            'destroy_ses':  { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){39}(\S*)" },
+            'sequence':     { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){40}(\S*)" },
+            'get_lease_t':  { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){41}(\S*)" },
+            'reclaim_comp': { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){42}(\S*)" },
+            'layoutget':    { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){43}(\S*)" },
+            'getdevinfo':   { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){44}(\S*)" },
+            'layoutcommit': { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){45}(\S*)" },
+            'layoutreturn': { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){46}(\S*)" },
+            'getdevlist':   { 'description':'dummy description', 're':  ".*proc4 (?:\S*\s){47}(\S*)" }
+        }
+    },
+    {
         'group': 'nfs_server',
-        'tests': [ 'stat.S_ISREG(os.stat("/proc/net/rpc/nfsd").st_mode)', 'test_proc3("/proc/net/rpc/nfsd")' ],
+        'tests': [ 'stat.S_ISREG(os.stat("/proc/net/rpc/nfsd").st_mode)', 'test_proc("/proc/net/rpc/nfsd", "proc3")' ],
         'prefix': 'nfsd_v3_',
         #  The next 4 lines can be at the 'group' level or the 'name' level
         'file': '/proc/net/rpc/nfsd',
@@ -99,6 +158,78 @@ configtable = [
             'pathconf':    { 'description':'dummy description', 're':  ".*proc3 (?:\S*\s){21}(\S*)" },
             'commit':      { 'description':'dummy description', 're':  ".*proc3 (?:\S*\s){22}(\S*)" }
         },
+    },
+    {
+        'group': 'nfs_server_v4',
+        'tests': [ 'stat.S_ISREG(os.stat("/proc/net/rpc/nfsd").st_mode)', 'test_proc("/proc/net/rpc/nfsd", "proc4ops")' ],
+        'prefix': 'nfsd_v4_',
+        #  The next 4 lines can be at the 'group' level or the 'name' level
+        'file': '/proc/net/rpc/nfsd',
+        'value_type': 'float',
+        'units': 'calls/sec',
+        'format': '%f',
+        'names': {
+            'total':         { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){2}(\d+.*\d)\n" },
+            'op0-unused':    { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){1}(\S*)" },
+            'op1-unused':    { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){2}(\S*)" },
+            'op2-future':    { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){3}(\S*)" },
+            'access':        { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){4}(\S*)" },
+            'close':         { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){5}(\S*)" },
+            'commit':        { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){6}(\S*)" },
+            'create':        { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){7}(\S*)" },
+            'delegpurge':    { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){8}(\S*)" },
+            'delegreturn':   { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){9}(\S*)" },
+            'getattr':       { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){10}(\S*)" },
+            'getfh':         { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){11}(\S*)" },
+            'link':          { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){12}(\S*)" },
+            'lock':          { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){13}(\S*)" },
+            'lockt':         { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){14}(\S*)" },
+            'locku':         { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){15}(\S*)" },
+            'lookup':        { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){16}(\S*)" },
+            'lookup_root':   { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){17}(\S*)" },
+            'nverify':       { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){18}(\S*)" },
+            'open':          { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){19}(\S*)" },
+            'openattr':      { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){20}(\S*)" },
+            'open_conf':     { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){21}(\S*)" },
+            'open_dgrd':     { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){22}(\S*)" },
+            'putfh':         { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){23}(\S*)" },
+            'putpubfh':      { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){24}(\S*)" },
+            'putrootfh':     { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){25}(\S*)" },
+            'read':          { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){26}(\S*)" },
+            'readdir':       { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){27}(\S*)" },
+            'readlink':      { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){28}(\S*)" },
+            'remove':        { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){29}(\S*)" },
+            'rename':        { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){30}(\S*)" },
+            'renew':         { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){31}(\S*)" },
+            'restorefh':     { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){32}(\S*)" },
+            'savefh':        { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){33}(\S*)" },
+            'secinfo':       { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){34}(\S*)" },
+            'setattr':       { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){35}(\S*)" },
+            'setcltid':      { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){36}(\S*)" },
+            'setcltidconf':  { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){37}(\S*)" },
+            'verify':        { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){38}(\S*)" },
+            'write':         { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){39}(\S*)" },
+            'rellockowner':  { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){40}(\S*)" },
+            'bc_ctl':        { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){41}(\S*)" },
+            'bind_conn':     { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){42}(\S*)" },
+            'exchange_id':   { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){43}(\S*)" },
+            'create_ses':    { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){44}(\S*)" },
+            'destroy_ses':   { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){45}(\S*)" },
+            'free_stateid':  { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){46}(\S*)" },
+            'getdirdeleg':   { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){47}(\S*)" },
+            'getdevinfo':    { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){48}(\S*)" },
+            'getdevlist':    { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){49}(\S*)" },
+            'layoutcommit':  { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){50}(\S*)" },
+            'layoutget':     { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){51}(\S*)" },
+            'layoutreturn':  { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){52}(\S*)" },
+            'secinfononam':  { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){53}(\S*)" },
+            'sequence':      { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){54}(\S*)" },
+            'set_ssv':       { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){55}(\S*)" },
+            'test_stateid':  { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){56}(\S*)" },
+            'want_deleg':    { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){57}(\S*)" },
+            'destroy_clid':  { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){58}(\S*)" },
+            'reclaim_comp':  { 'description':'dummy description', 're':  ".*proc4ops (?:\S*\s){59}(\S*)" }
+        },
     }
 ]
 
@@ -124,8 +255,27 @@ def metric_init(params):
                break
         if not tests_passed:
             continue
+
+        # 2nd param defines number of params that will follow (differs between NFS versions)
+        max_plimit = re.split("\W+", p_match.group())[1]
+
+        # Parse our defined params list in order to ensure list will not exceed max_plimit
+        n = 0
+        names_keys = configtable[i]['names'].keys()
+        keys_to_remove = []
+        for _tmpkey in names_keys:
+            _tmplist = names_keys
+            param_pos = re.split("{(\d+)\}", configtable[i]['names'][_tmpkey].values()[0])[1]
+	    if int(param_pos) > int(max_plimit):
+                keys_to_remove.append(_tmpkey)
+            n += 1
+
+        if len(keys_to_remove) > 0:
+            for key in keys_to_remove:
+                names_keys.remove(key)
+
         #  For each name in the group ...
-        for name in configtable[i]['names'].keys():
+        for name in names_keys:
             #  ... set up dictionary ...
             if 'format' in configtable[i]['names'][name]:
 		format_str = configtable[i]['names'][name]['format']


### PR DESCRIPTION
NFS v4 data  is shown in Ganglia under separate (new) metric groups "nfs_client_v4 metrics" and "nfsd_server_v4 metrics".

Since v4 varies between versions in number of values given by /proc/net/rpc/nfs I changed a code a bit, so it gathers the data only for the values it is able to get from proc.
