### PR TITLE
multi_interface.py: Adding regular expression support for the exclude_interface parameter

### DIFF
--- a/network/multi_interface/conf.d/multi_interface.pyconf
+++ b/network/multi_interface/conf.d/multi_interface.pyconf
@@ -12,9 +12,9 @@ modules {
     }
 
     # Alternatively leave the interfaces list at value = "" then exclude
-    # specific interfaces e.g. dummy, lo etc. 
+    # specific interfaces by name or regular expression e.g. dummy, lo, eth[0-9]+ etc. 
     param excluded_interfaces {
-      value = "dummy0 eth0_rename tunl0 gre0"
+      value = "lo vnet[0-9]+"
     }
 
 

--- a/network/multi_interface/python_modules/multi_interface.py
+++ b/network/multi_interface/python_modules/multi_interface.py
@@ -113,27 +113,31 @@ def metric_cleanup():
     pass
     
 def get_interfaces(watch_interfaces, excluded_interfaces):
-	global INTERFACES
+   global INTERFACES
+   if_excluded = 0
         
-        # check if particular interfaces have been specifieid. Watch only those
-        if watch_interfaces != "":
-            INTERFACES = watch_interfaces.split(" ")
-            
-        else:
+   # check if particular interfaces have been specifieid. Watch only those
+   if watch_interfaces != "":
+      INTERFACES = watch_interfaces.split(" ")      
+   else:
+      if excluded_interfaces != "":
+         excluded_if_list = excluded_interfaces.split(" ")
+      f = open(net_stats_file, "r")
+      for line in f:
+         # Find only lines with :
+         if re.search(":", line):
+            a = line.split(":")
+            dev_name = a[0].lstrip()
+                    
+            # Determine if interface is excluded by name or regex
+            for ex in excluded_if_list:
+               if re.match(ex,dev_name):
+                  if_excluded = 1
 
-	    if excluded_interfaces != "":
-		excluded_if_list = excluded_interfaces.split(" ")
-        
-            f = open(net_stats_file, "r")
-            for line in f:
-                # Find only lines with :
-                if re.search(":", line):
-                    a = line.split(":")
-                    dev_name = a[0].lstrip()
-		    if dev_name not in excluded_if_list:
-                        INTERFACES.append(dev_name)
-
-	return 0
+            if not if_excluded:
+               INTERFACES.append(dev_name)
+            if_excluded = 0
+   return 0
 
 
 def get_metrics():


### PR DESCRIPTION
Adding regular expression support for the exclude_interface parameter for exclude interfaces matching regular expressions, particular useful for hypervisor having a many vnet interfaces as example.
Also indention fixed (spaces vs. tabs)
