### PR TITLE
hwmon reads /sys/class/hwmon and reports temperatures

### DIFF
--- a/system/hwmon/README.mkdn
+++ b/system/hwmon/README.mkdn
@@ -1,0 +1,18 @@
+hwmon
+=====
+
+Python module for ganglia 3.1.
+
+This module collects system temperature data (and anything else) 
+from the devices in `/sys/class/hwmon`.
+
+Install
+=======
+
+1. Copy `hwmon.py` to your python modules directory (often `/usr/lib/ganglia/python_modules`).
+2. Copy `hwmon.pyconf` to your ganglia config directory (often `/etc/ganglia/conf.d`).
+3. Restart gmond.
+
+## AUTHOR
+
+Author: Adam Compton <comptona@gmail.com>

--- a/system/hwmon/conf.d/hwmon.pyconf
+++ b/system/hwmon/conf.d/hwmon.pyconf
@@ -1,0 +1,14 @@
+modules {
+  module {
+    name = "hwmon"
+    language = "python"
+  }
+}
+
+collection_group {
+  collect_every = 10
+  time_threshold = 50
+  metric {
+    name_match = "hwmon_(.+)"
+  }
+}

--- a/system/hwmon/python_modules/hwmon.py
+++ b/system/hwmon/python_modules/hwmon.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+
+root = '/sys/class/hwmon'
+descriptors = []
+mapping = {}
+
+import os, glob, re
+
+def temp_finder(name):
+    val = open(mapping[name]).read().strip()
+    return int(val) / 1000.0
+
+def metric_init(params):
+    global descriptors
+
+    sensors = sorted(glob.glob(os.path.join(root, 'hwmon*')))
+
+    for s in sensors:
+        temps = glob.glob(os.path.join(s, 'device/temp*_input'))
+        # dict values are default labels if no label files exist
+        probes = dict(zip(temps, [os.path.basename(x) for x in temps]))
+
+        for i in probes.keys():
+            try:
+                fname = i.replace('input', 'label')
+                fhandle = open(fname, 'r')
+                probes[i] = fhandle.read().strip().replace(' ', '_').lower()
+                fhandle.close()
+            except (IOError, OSError):
+                pass
+
+        for i, l in probes.iteritems():
+            num = re.search('\d+', i)
+            device = i[num.start():num.end()]
+            name = 'hwmon_dev%s_%s' % (device, l)
+            item = {'name': name,
+                    'call_back': temp_finder,
+                    'time_max': 90,
+                    'value_type': 'float',
+                    'units': 'C',
+                    'slope': 'both',
+                    'format': '%0.2f',
+                    'description': 'Temperature for hwmon probe %s' % l,
+                    'groups': 'hwmon'}
+            descriptors.append(item)
+            mapping[name] = i
+
+    return descriptors
+
+def metric_cleanup():
+    '''Clean up the metric module.'''
+    pass
+
+if __name__ == '__main__':
+    metric_init(None)
+    for d in descriptors:
+        v = d['call_back'](d['name'])
+        print 'value for %s: %s' % (d['name'],  str(v))


### PR DESCRIPTION
It automatically figures out what sensors exist and names them with either the provided label or with a stable name based on the path to the sensor.

Tested on Ubuntu 12.04, Gentoo, kernel versions 3.2.0 and 3.10.7.
