### PR TITLE
Update elasticsearch.py

### DIFF
--- a/elasticsearch/python_modules/elasticsearch.py
+++ b/elasticsearch/python_modules/elasticsearch.py
@@ -127,7 +127,7 @@ def update_result(result, url):
     diff = now - last_update
     if diff > 20:
         print '[elasticsearch] ' + str(diff) + ' seconds passed - Fetching ' + url
-        result = json.load(urllib.urlopen(url, None, 2))
+        result = json.load(urllib.urlopen(url))
         last_update = now
 
     return result
@@ -220,7 +220,7 @@ def metric_init(params):
         url_indices = '{0}{1}/_stats'.format(host, index)
         print('[elasticsearch] Fetching ' + url_indices)
 
-        r_indices = json.load(urllib.urlopen(url_indices, None, 2))
+        r_indices = json.load(urllib.urlopen(url_indices))
         descriptors += get_indices_descriptors(index,
                                                Desc_Skel,
                                                r_indices,


### PR DESCRIPTION
The value for 'proxies', which was '2', should be a mapping, not an integer. Not sure why this was '2', but removing it seems to fix the problem.

Someone else also reported this issue here: https://github.com/ganglia/gmond_python_modules/issues/101
