### PR TITLE
Zero rates when queue is idle

### DIFF
--- a/rabbit/conf.d/rabbitmq.pyconf
+++ b/rabbit/conf.d/rabbitmq.pyconf
@@ -28,6 +28,10 @@ modules {
     param metric_group {
       value = "rmq"
     }
+    
+    param zero_rates_when_idle {
+      value = "True"
+    }
 
   }
 }


### PR DESCRIPTION
When queue is idle, values of all rates ('rmq_backing_queue_ack_egress_rate', 'rmq_backing_queue_ack_ingress_rate',    'rmq_backing_queue_egress_rate',    'rmq_backing_queue_ingress_rate') are freezed. But sometimes you want ignore metrics from idle queues.
