### PR TITLE
Custom mysql port and timeout integer fix

### DIFF
--- a/mysqld/python_modules/mysql.py
+++ b/mysqld/python_modules/mysql.py
@@ -378,8 +378,8 @@ def metric_init(params):
 		host = params.get('host', 'localhost'),
 		user = params.get('user'),
 		passwd = params.get('passwd'),
-		port = params.get('port', 3306),
-		connect_timeout = params.get('timeout', 30),
+		port = int(params.get('port', 3306)),
+		connect_timeout = int(params.get('timeout', 30)),
 	)
 	if params.get('unix_socket', '') != '':
 		mysql_conn_opts['unix_socket'] = params.get('unix_socket')


### PR DESCRIPTION
When mysql.pyconf configured with custom port:

```
    param port {
      value = 3307
    }
```

gmond gives into log:

```
[PYTHON] Can't call the metric_init function in the python module [mysql].#012
```

and further investigation with
_gmond -d 1_
shows

```
[PYTHON] Can't call the metric_init function in the python module [mysql].
Traceback (most recent call last):
  File "/usr/lib64/ganglia/python_modules/mysql.py", line 1005, in metric_init
    update_stats(REPORT_INNODB, REPORT_MASTER, REPORT_SLAVE)
  File "/usr/lib64/ganglia/python_modules/mysql.py", line 86, in update_stats
    conn = MySQLdb.connect(**mysql_conn_opts)
  File "/usr/lib64/python2.6/site-packages/MySQLdb/__init__.py", line 81, in Connect
    return Connection(*args, **kwargs)
  File "/usr/lib64/python2.6/site-packages/MySQLdb/connections.py", line 187, in __init__
    super(Connection, self).__init__(*args, **kwargs2)
TypeError: an integer is required
```

Method params.get converted explicitly as integer with timeout and port option.
