### PR TITLE
Improve handling of NVIDIA GPU fan speeds

### DIFF
--- a/gpu/nvidia/python_modules/nvidia.py
+++ b/gpu/nvidia/python_modules/nvidia.py
@@ -86,7 +86,12 @@ def gpu_device_handler(name):
     elif (metric == 'mem_util'):
         return nvmlDeviceGetUtilizationRates(gpu_device).memory
     elif (metric == 'fan'):
-        return nvmlDeviceGetFanSpeed(gpu_device)
+        try:
+            return nvmlDeviceGetFanSpeed(gpu_device)
+        except NVMLError, nvmlError:
+            # Not all GPUs have fans - a fatal error would not be appropriate
+            if NVML_ERROR_NOT_SUPPORTED == nvmlError.value:
+                return 0
     elif (metric == 'ecc_mode'):
         try:
             ecc_mode = nvmlDeviceGetPendingEccMode(gpu_device)
@@ -150,7 +155,7 @@ def metric_init(params):
 
     build_descriptor('gpu_num', gpu_num_handler, default_time_max, 'uint', 'GPUs', 'zero', '%u', 'Total number of GPUs', 'gpu')
     build_descriptor('gpu_driver', gpu_driver_version_handler, default_time_max, 'string', '', 'zero', '%s', 'GPU Driver Version', 'gpu')
- 
+
     for i in range(get_gpu_num()):
         build_descriptor('gpu%s_type' % i, gpu_device_handler, default_time_max, 'string', '', 'zero', '%s', 'GPU%s Type' % i, 'gpu')
         build_descriptor('gpu%s_graphics_speed' % i, gpu_device_handler, default_time_max, 'uint', 'MHz', 'both', '%u', 'GPU%s Graphics Speed' % i, 'gpu')


### PR DESCRIPTION
NVIDIA GPUs can be active (with a fan) or passive (without a fan).
We shouldn't treat a card without a fan as a fatal condition, so
return 0 rather than generating an exception.
