### PR TITLE
Update iface.py to fix the error of Interface name

### DIFF
--- a/network/iface/python_modules/iface.py
+++ b/network/iface/python_modules/iface.py
@@ -80,7 +80,7 @@ class UpdateMetricThread(threading.Thread):
 
         for line in f:
             if re.search(':', line):
-                tokens  = re.split('\s+', line.strip())
+                tokens  = re.split('[:\s]+', line.strip())
                 iface   = tokens[0].strip(':')
 
                 self.metric.update({
@@ -151,7 +151,7 @@ def metric_init(params):
 
     for line in f:
         if re.search(':', line):
-            tokens  = re.split('\s+', line.strip())
+            tokens  = re.split('[:\s]+', line.strip())
             iface   = tokens[0].strip(':')
 
             for way in ('tx', 'rx'):


### PR DESCRIPTION
Sometimes, 'bytes' after 'Interface' are too long, and there is no space between 'Interface' and  'bytes' in /proc/net/dev.
For example, in my /proc/net/dev there is one line begin with 'eth0:137719774170', and the iface will be identified as 'eth0:137719774170'.
![netdev](https://cloud.githubusercontent.com/assets/1490540/4040970/86fa9cd0-2cef-11e4-959d-15e0841a432e.png)
