### PR TITLE
Don't crash if db was never vacuumed

### DIFF
--- a/postgresql/python_modules/postgres.py
+++ b/postgresql/python_modules/postgres.py
@@ -146,8 +146,8 @@ def pg_metrics_queries():
     pg_stat_table_values = results[0]
     seqscan = int(pg_stat_table_values[0])
     idxfetch = int(pg_stat_table_values[1])
-    hours_since_vacuum = int(pg_stat_table_values[2])
-    hours_since_analyze = int(pg_stat_table_values[3])
+    hours_since_vacuum = int(pg_stat_table_values[2]) if pg_stat_table_values[2] != None else None
+    hours_since_analyze = int(pg_stat_table_values[3]) if pg_stat_table_values[3] != None else None
     pg_metrics.update(
         {'Pypg_tup_seqscan':seqscan,
         'Pypg_tup_idxfetch':idxfetch,


### PR DESCRIPTION
If the connected DB was never vacuumed or analyzed the entire plugin crashed trying to cast to integer a None from the last_vacuum and last_analyze columns
