### PR TITLE
Fix default behavior for diskstat config

### DIFF
--- a/diskstat/conf.d/diskstat.pyconf
+++ b/diskstat/conf.d/diskstat.pyconf
@@ -7,9 +7,9 @@ modules {
 
     # Specify devices you want to monitor or if empty it will 
     # pick all devices
-    param devices {
-      value = ''
-    }
+    #param devices {
+    #  value = ''
+    #}
 
     #param device-mapper {
     #  value = 'true'


### PR DESCRIPTION
The default behavior for the diskstat config does not work. No data is reported because we only check for None in the plugin. This was reported in #150 