### PR TITLE
Changed conf file such that level and ipmitool_bin are defined

### DIFF
--- a/ipmi/conf.d/ipmi.pyconf
+++ b/ipmi/conf.d/ipmi.pyconf
@@ -31,8 +31,12 @@ modules {
     }
     
     # Location of ipmitool binary
-    param timeout_bin {
+    param ipmitool_bin {
       value = "/usr/bin/ipmitool"
+    }
+    
+    param level {
+      value = "USER"
     }
     
   }


### PR DESCRIPTION
The original version does not work because ipmitool_bin and level are not defined properly or at in the ipmi.pyconf