### PR TITLE
More memcached metrics

### DIFF
--- a/memcached/conf.d/memcached.conf
+++ b/memcached/conf.d/memcached.conf
@@ -110,5 +110,24 @@ collection_group {
     title = "Misses/sec"
     value_threshold = 0
   }
-
+  metric {
+    name  = "mc_reclaimed"
+    title = "Number of times an entry was stored using memory from an expired entry"
+    value_threshold = 0
+  }
+  metric {
+    name  = "mc_expired_unfetched"
+   title = "Items pulled from LRU that were never touched by get/incr/append/etc before expiring"
+    value_threshold = 0
+  }
+  metric {
+    name  = "mc_evicted_unfetched"
+    title = "Items evicted from LRU that were never touched by get/incr/append/etc."
+    value_threshold = 0
+  }
+  metric {
+    name  = "mc_crawler_reclaimed"
+    title = "Total items freed by LRU Crawler"
+    value_threshold = 0
+  }
 }

--- a/memcached/conf.d/memcached.conf.tmpl
+++ b/memcached/conf.d/memcached.conf.tmpl
@@ -105,5 +105,24 @@ collection_group {
     title = "Misses/sec"
     value_threshold = 0
   }
-
+  metric {
+    name  = "mc_reclaimed"
+    title = "Number of times an entry was stored using memory from an expired entry"
+    value_threshold = 0
+  }
+  metric {
+    name  = "mc_expired_unfetched"
+   title = "Items pulled from LRU that were never touched by get/incr/append/etc before expiring"
+    value_threshold = 0
+  }
+  metric {
+    name  = "mc_evicted_unfetched"
+    title = "Items evicted from LRU that were never touched by get/incr/append/etc."
+    value_threshold = 0
+  }
+  metric {
+    name  = "mc_crawler_reclaimed"
+    title = "Total items freed by LRU Crawler"
+    value_threshold = 0
+  }
 }

--- a/memcached/python_modules/memcached.py
+++ b/memcached/python_modules/memcached.py
@@ -255,6 +255,30 @@ def metric_init(params):
                 "description": "Number of valid items removed from cache to free memory for new items",
                 }))
     descriptors.append(create_desc(Desc_Skel, {
+                "name"       : mp+"_reclaimed",
+                "units"      : "items",
+                "slope"      : "both",
+                "description": "Number of times an entry was stored using memory from an expired entry",
+                }))
+    descriptors.append(create_desc(Desc_Skel, {
+                "name"       : mp+"_expired_unfetched",
+                "units"      : "items",
+                "slope"      : "both",
+                "description": "Items pulled from LRU that were never touched by get/incr/append/etc before expiring",
+                }))
+    descriptors.append(create_desc(Desc_Skel, {
+                "name"       : mp+"_evicted_unfetched",
+                "units"      : "items",
+                "slope"      : "both",
+                "description": "Items evicted from LRU that were never touched by get/incr/append/etc.",
+                }))
+    descriptors.append(create_desc(Desc_Skel, {
+                "name"       : mp+"_crawler_reclaimed",
+                "units"      : "items",
+                "slope"      : "both",
+                "description": "Total items freed by LRU Crawler",
+                }))
+    descriptors.append(create_desc(Desc_Skel, {
                 "name"       : mp+"_get_hits",
                 "units"      : "items",
                 "slope"      : "positive",
@@ -313,6 +337,10 @@ def metric_init(params):
                 mp+"_limit_maxbytes",
                 mp+"_curr_connections",
                 mp+"_evictions",
+                mp+"_reclaimed",
+                mp+"_expired_unfetched",
+                mp+"_evicted_unfetched",
+                mp+"_crawler_reclaimed",
                 ]:
                 descriptors.remove(d)
         for d in descriptors:


### PR DESCRIPTION
Add additional memcached ganglia metrics

From the memcached protocol.txt[0] add these metrics to the ganglia plugin:
* reclaimed
  Number of times an entry was stored using memory from an expired entry
* expired_unfetched
  Items pulled from LRU that were never touched by get/incr/append/etc
  before expiring
* evicted_unfetched
  Items evicted from LRU that were never touched by get/incr/append/etc.
* crawler_reclaimed
  Total items freed by LRU Crawler

Update config template to match

[0]: https://github.com/memcached/memcached/blob/master/doc/protocol.txt