### PR TITLE
Rabbitmq emit overview api metrics

### DIFF
--- a/rabbit/python_modules/rabbitmq.py
+++ b/rabbit/python_modules/rabbitmq.py
@@ -77,12 +77,10 @@ keyToPath['rmq_mem_used'] = "%s{0}mem_used".format(JSON_PATH_SEPARATOR)
 keyToPath['rmq_proc_used'] = "%s{0}proc_used".format(JSON_PATH_SEPARATOR)
 keyToPath['rmq_sockets_used'] = "%s{0}sockets_used".format(JSON_PATH_SEPARATOR)
 keyToPath['rmq_mem_alarm'] = "%s{0}mem_alarm".format(JSON_PATH_SEPARATOR)  # Boolean
-keyToPath['rmq_mem_binary'] = "%s{0}mem_binary".format(JSON_PATH_SEPARATOR)
-keyToPath['rmq_mem_code'] = "%s{0}mem_code".format(JSON_PATH_SEPARATOR)
-keyToPath['rmq_mem_proc_used'] = "%s{0}mem_proc_used".format(JSON_PATH_SEPARATOR)
 keyToPath['rmq_running'] = "%s{0}running".format(JSON_PATH_SEPARATOR)  # Boolean
 
-NODE_METRICS = ['rmq_disk_free', 'rmq_mem_used', 'rmq_disk_free_alarm', 'rmq_running', 'rmq_proc_used', 'rmq_mem_proc_used', 'rmq_fd_used', 'rmq_mem_alarm', 'rmq_mem_code', 'rmq_mem_binary', 'rmq_sockets_used']
+NODE_METRICS = ['rmq_disk_free', 'rmq_mem_used', 'rmq_disk_free_alarm', 'rmq_running', 'rmq_proc_used',
+    'rmq_fd_used', 'rmq_mem_alarm', 'rmq_sockets_used']
 
 # EXCHANGE METRICS #
 


### PR DESCRIPTION
Two new features are added in this pull request.

- The information in the rabbitmq /api/overview REST endpoint is emitted to ganglia. These are useful high level metrics that can be monitored to assess the overall health of the rabbit cluster. New emitted metrics are:
```
value for rmq_overview_message_stats_publish___- is 1485667.0
value for rmq_overview_message_stats_ack___- is 31397.0
value for rmq_overview_message_stats_deliver_get___- is 5262504.0
value for rmq_overview_message_stats_deliver___- is 31397.0
value for rmq_overview_message_stats_deliver_no_ack___- is 5231107.0
value for rmq_overview_queue_totals_messages___- is 0.0
value for rmq_overview_queue_totals_messages_ready___- is 0.0
value for rmq_overview_queue_totals_messages_unacknowledged___- is 0.0
value for rmq_overview_object_totals_consumers___- is 9.0
value for rmq_overview_object_totals_queues___- is 12.0
value for rmq_overview_object_totals_exchanges___- is 11.0
value for rmq_overview_object_totals_connections___- is 15.0
value for rmq_overview_object_totals_channels___- is 15.0
```
- For each per-node level metrics the summation of these metrics are now emitted. The sum metric is useful for reporting systems that use separation of concerns on the metric name and the host name such that host names do not appear in the metric names. Examples of these new metrics are:
```
value for rmq_disk_free___total___- is 2472503488512.0
value for rmq_disk_free___rabbit@hostname1___- is 1303971811328.0
value for rmq_disk_free___rabbit@hostname2___- is 1168531677184.0
value for rmq_mem_used___total___- is 102535712.0
value for rmq_mem_used___rabbit@hostname1___- is 44239472.0
value for rmq_mem_used___rabbit@hostname2___- is 58296240.0
value for rmq_disk_free_alarm___total___- is 0.0
value for rmq_disk_free_alarm___rabbit@hostname1___- is 0.0
value for rmq_disk_free_alarm___rabbit@hostname2___- is 0.0
```