### PR TITLE
Dyn elasticsearch version

### DIFF
--- a/elasticsearch/python_modules/elasticsearch.py
+++ b/elasticsearch/python_modules/elasticsearch.py
@@ -187,7 +187,10 @@ def metric_init(params):
 
     host = params.get('host', 'http://localhost:9200/')
 
-    result = json.load(urllib.urlopen(host))
+    try:
+        result = json.load(urllib.urlopen(host))
+    except (ValueError, IOError):
+        result = {}
 
     host_version = result.get('version',{}).get('number') or "1.2"
     version = params.get('version', host_version)

--- a/elasticsearch/python_modules/elasticsearch.py
+++ b/elasticsearch/python_modules/elasticsearch.py
@@ -187,12 +187,17 @@ def metric_init(params):
 
     host = params.get('host', 'http://localhost:9200/')
 
-    version = params.get('version', '1.2')
-    
+    result = json.load(urllib.urlopen(host))
+
+    host_version = result.get('version',{}).get('number') or "1.2"
+    version = params.get('version', host_version)
+
     m = re.match('(?P<major>\d+)\.(?P<minor>(\d+(\.\d+)*))', version)
-     
+
     if m and m.group('major') == '0':
         url_cluster = '{0}_cluster/nodes/_local/stats?all=true'.format(host)
+    elif m and m.group('major') == '1' and m.group('minor') == '3.2':
+        url_cluster = '{0}_nodes/_local/stats'.format(host)
     else:
         url_cluster = '{0}_cluster/state/nodes'.format(host)
 


### PR DESCRIPTION
Elasticsearch 1.3.2 has a different url path for metrics. This PR matches for that with the correct path, and makes version lookups dynamic from the server, while still allowing a default and override in the config file. 