### PR TITLE
Update infiniband.py

### DIFF
--- a/network/infiniband/python_modules/infiniband.py
+++ b/network/infiniband/python_modules/infiniband.py
@@ -332,10 +332,12 @@ def metric_init(params):
                 with open(lid_file) as f:
                     # Linux sysfs lists the port_lid in hex
                     port_lid = int(f.readline().split(' ')[0], 0)
+                    if port_lid == 0:
+                        continue
+                    IB_PORTS[port_lid] = ib_device
             except IOError:
                 print("Unable to read IB port LID # from file: %s" % lid_file)
-            IB_PORTS[port_lid] = ib_device
-
+            
             # Create definitions for the known perfquery InfiniBand metrics
             for metric_name, metric_settings in KNOWN_PERFQUERY_METRICS.iteritems():
                 name_prefix = metric_settings['name_prefix']


### PR DESCRIPTION
2 changes:
1. inserted IB_PORTS[port_lid} into try, as port_lid might not be defined otherwise
2. if some of the ports are inactive (no cable connected), perfquery will not show them at all, but /sys/class/infiniband will recurse through them and during update_metrics bomb out.
unconnected ports have lid '0' so bypass these ports