### PR TITLE
add gpu_use_num metric depend on running process

### DIFF
--- a/gpu/nvidia/README
+++ b/gpu/nvidia/README
@@ -60,4 +60,5 @@ The following metrics have been implemented:
 * gpu_bar1_memory
 * gpu_shutdown_temp
 * gpu_slowdown_temp
+* gpu_use_num
 

--- a/gpu/nvidia/conf.d/nvidia.pyconf
+++ b/gpu/nvidia/conf.d/nvidia.pyconf
@@ -123,6 +123,10 @@ collection_group {
     title= "\\1 ECC Mode"
     value_threshold = 1.0
   } 
+  metric {
+    name = "gpu_use_num"
+    title = "GPU Use Count"
+  }
 }
 
 collection_group {

--- a/gpu/nvidia/python_modules/nvidia.py
+++ b/gpu/nvidia/python_modules/nvidia.py
@@ -65,6 +65,13 @@ def build_descriptor(name, call_back, time_max, value_type, units, slope, format
 
 def get_gpu_num():
     return int(nvmlDeviceGetCount())
+def get_gpu_use_num(name):
+    use_num = 0
+    for i in range(get_gpu_num()):
+         is_use = gpu_device_handler('gpu%s_process' %i)
+         if(int(is_use)):
+            use_num += 1
+    return use_num
 
 def gpu_num_handler(name):
     return get_gpu_num()
@@ -187,6 +194,9 @@ def gpu_device_handler(name):
        violation_dur[gpu_id] = newTime
        print rate
        return rate
+    elif (metric == 'process'):
+        procs = nvmlDeviceGetComputeRunningProcesses(gpu_device)
+        return len(procs)
     else:
         print "Handler for %s not implemented, please fix in gpu_device_handler()" % metric
         os._exit(1)
@@ -204,6 +214,7 @@ def metric_init(params):
     default_time_max = 90
 
     build_descriptor('gpu_num', gpu_num_handler, default_time_max, 'uint', 'GPUs', 'zero', '%u', 'Total number of GPUs', 'gpu')
+    build_descriptor('gpu_use_num', gpu_num_handler, default_time_max, 'uint', 'GPUs', 'zero', '%u', 'Total number of Use  GPUs', 'gpu')
     build_descriptor('gpu_driver', gpu_driver_version_handler, default_time_max, 'string', '', 'zero', '%s', 'GPU Driver Version', 'gpu')
 
     for i in range(get_gpu_num()):


### PR DESCRIPTION
A gpu at the same time can only have one process, by judging whether there has process to determine whether the gpu is in use，and then we can  use the situation to a reasonable allocation of gpu resources.

![gpu_use](https://cloud.githubusercontent.com/assets/5434158/10005418/c57d8420-60e9-11e5-8c96-3036163715e4.jpg)
