### PR TITLE
Fix nvidia.pyconf regex

### DIFF
--- a/gpu/nvidia/conf.d/nvidia.pyconf
+++ b/gpu/nvidia/conf.d/nvidia.pyconf
@@ -10,105 +10,105 @@ collection_group {
   time_threshold = 50
 
   metric {
-    name_match = "([\\S]+)_graphics_clock_report"
+    name_match = "gpu([\\d]+)_graphics_clock_report"
     name = "\\1_graphics_clock_report"
     title = "\\1 Graphics Clock"
     value_threshold = 1.0
   }
 
   metric {
-    name_match = "([\\S]+)_sm_clock_report"
+    name_match = "gpu([\\d]+)_sm_clock_report"
     name = "\\1_sm_clock_report"
     title = "\\1 SM Clock"
     value_threshold = 1.0
   }
 
   metric {
-    name_match = "([\\S]+)_mem_clock_report"
+    name_match = "gpu([\\d]+)_mem_clock_report"
     name = "\\1_mem_clock_report"
     title = "\\1 Memory Clock"
     value_threshold = 1.0
   }
 
   metric {
-    name_match = "([\\S]+)_temp"
+    name_match = "gpu([\\d]+)_temp"
     name = "\\1_temp"
     title = "\\1 Temperature"
     value_threshold = 1.0
   }
 
   metric {
-    name_match = "([\\S]+)_util"
+    name_match = "gpu([\\d]+)_util"
     name = "\\1_util"
     title= "\\1 GPU Utilization"
     value_threshold = 1.0
   }
 
   metric {
-    name_match = "([\\S]+)_mem_util"
+    name_match = "gpu([\\d]+)_mem_util"
     name = "\\1_mem_util"
     title= "\\1 Memory Utilization"
     value_threshold = 1.0
   }
 
   metric {
-    name_match = "([\\S]+)_fb_memory"
+    name_match = "gpu([\\d]+)_fb_memory"
     name = "\\1_fb_memory"
     title= "\\1 Frame Buffer Memory Used"
     value_threshold = 1.0
   }
 
   metric {
-    name_match = "([\\S]+)_fan"
+    name_match = "gpu([\\d]+)_fan"
     name = "\\1_fan"
     title= "\\1 Fan Speed"
     value_threshold = 1.0
   }
 
   metric {
-    name_match = "([\\S]+)_power_usage_report"
+    name_match = "gpu([\\d]+)_power_usage_report"
     name = "\\1_power_usage"
     title= "\\1 Power Usage"
     value_threshold = 1.0
   }
 
   metric {
-    name_match = "([\\S]+)_ecc_db_error"
+    name_match = "gpu([\\d]+)_ecc_db_error"
     title= "\\1 Double Bit ECC Errors"
     value_threshold = 1.0
   }
   
   metric {
-    name_match = "([\\S]+)_ecc_sb_error"
+    name_match = "gpu([\\d]+)_ecc_sb_error"
     title= "\\1 Single Bit ECC Error Count"
     value_threshold = 1.0
   }
 
   metric {
-    name_match = "([\\S]+)_power_violation_report"
+    name_match = "gpu([\\d]+)_power_violation_report"
     title= "\\1 Power Violation Report"
     value_threshold = 1.0
   }
   
   metric {
-    name_match = "([\\S]+)_encoder_util"
+    name_match = "gpu([\\d]+)_encoder_util"
     title = "\\1 Encoder Utilization"
     value_threshold = 1.0 
   }
 
   metric {
-    name_match = "([\\S]+)_decoder_util"
+    name_match = "gpu([\\d]+)_decoder_util"
     title = "\\1 Decoder Utilization"
     value_threshold = 1.0
   }
   
   metric {
-    name_match = "([\\S]+)_bar1_memory"
+    name_match = "gpu([\\d]+)_bar1_memory"
     title = "\\1 Bar1 Memory"
   }
 
   metric {
-    name_match = "([\\S]+)_bar1_max_memory"
+    name_match = "gpu([\\d]+)_bar1_max_memory"
     title = "\\1 Bar1 Total Memory"
   } 
 }
@@ -118,7 +118,7 @@ collection_group {
   time_threshold = 1200
 
   metric {
-    name_match = "([\\S]+)_ecc_mode"
+    name_match = "gpu([\\d]+)_ecc_mode"
     name = "\\1_ecc_mode"
     title= "\\1 ECC Mode"
     value_threshold = 1.0
@@ -140,68 +140,68 @@ collection_group {
   }
 
   metric {
-    name_match = "([\\S]+)_type"
+    name_match = "gpu([\\d]+)_type"
     name = "\\1_type"
     title = "\\1 Type"
   }
 
   metric {
-    name_match = "([\\S]+)_uuid"
+    name_match = "gpu([\\d]+)_uuid"
     name = "\\1_uuid"
     title = "\\1 UUID"
   }
 
   metric {
-    name_match = "([\\S]+)_pci_id"
+    name_match = "gpu([\\d]+)_pci_id"
     name = "\\1_pci_id"
     title = "\\1 PCI ID"
   }
 
   metric {
-    name_match = "([\\S]+)_mem_total"
+    name_match = "gpu([\\d]+)_mem_total"
     name = "\\1_mem_total"
     title = "\\1 Memory Total"
   }
 
   metric {
-    name_match = "([\\S]+)_max_graphics_clock"
+    name_match = "gpu([\\d]+)_max_graphics_clock"
     name = "\\1_max_graphics_clock"
     title = "\\1 Max Graphics Clock"
     value_threshold = 1.0
   }
 
   metric {
-    name_match = "([\\S]+)_max_sm_clock"
+    name_match = "gpu([\\d]+)_max_sm_clock"
     name = "\\1_max_sm_clock"
     title = "\\1 Max SM Clock"
     value_threshold = 1.0
   }
 
   metric {
-    name_match = "([\\S]+)_max_mem_clock"
+    name_match = "gpu([\\d]+)_max_mem_clock"
     name = "\\1_max_mem_clock"
     title = "\\1 Max Memory Clock"
     value_threshold = 1.0
   }
 
   metric {
-    name_match = "([\\S]+)_serial"
+    name_match = "gpu([\\d]+)_serial"
     name = "\\1_serial"
     title = "\\1 Board Serial Number"
   }
   
   metric {
-    name_match = "([\\S]+)_shutdown_temp"
+    name_match = "gpu([\\d]+)_shutdown_temp"
     title = "\\1 Shutdown Temperature"
   }
 
   metric {
-    name_match = "([\\S]+)_slowdown_temp"
+    name_match = "gpu([\\d]+)_slowdown_temp"
     title = "\\1 Slowdown Temperature"
   }
   
    metric {
-    name_match = "([\\S]+)_power_man_limit"
+    name_match = "gpu([\\d]+)_power_man_limit"
     title= "\\1 Power Management Limit"
   } 
 }

--- a/gpu/nvidia/conf.d/nvidia.pyconf
+++ b/gpu/nvidia/conf.d/nvidia.pyconf
@@ -10,105 +10,105 @@ collection_group {
   time_threshold = 50
 
   metric {
-    name_match = "gpu([\\d]+)_graphics_clock_report"
+    name_match = "([\\S]+)_graphics_clock_report"
     name = "\\1_graphics_clock_report"
     title = "\\1 Graphics Clock"
     value_threshold = 1.0
   }
 
   metric {
-    name_match = "gpu([\\d]+)_sm_clock_report"
+    name_match = "([\\S]+)_sm_clock_report"
     name = "\\1_sm_clock_report"
     title = "\\1 SM Clock"
     value_threshold = 1.0
   }
 
   metric {
-    name_match = "gpu([\\d]+)_mem_clock_report"
+    name_match = "([\\S]+)_mem_clock_report"
     name = "\\1_mem_clock_report"
     title = "\\1 Memory Clock"
     value_threshold = 1.0
   }
 
   metric {
-    name_match = "gpu([\\d]+)_temp"
+    name_match = "([\\S]+)_temp"
     name = "\\1_temp"
     title = "\\1 Temperature"
     value_threshold = 1.0
   }
 
   metric {
-    name_match = "gpu([\\d]+)_util"
+    name_match = "([\\S]+)_util"
     name = "\\1_util"
     title= "\\1 GPU Utilization"
     value_threshold = 1.0
   }
 
   metric {
-    name_match = "gpu([\\d]+)_mem_util"
+    name_match = "([\\S]+)_mem_util"
     name = "\\1_mem_util"
     title= "\\1 Memory Utilization"
     value_threshold = 1.0
   }
 
   metric {
-    name_match = "gpu([\\d]+)_fb_memory"
+    name_match = "([\\S]+)_fb_memory"
     name = "\\1_fb_memory"
     title= "\\1 Frame Buffer Memory Used"
     value_threshold = 1.0
   }
 
   metric {
-    name_match = "gpu([\\d]+)_fan"
+    name_match = "([\\S]+)_fan"
     name = "\\1_fan"
     title= "\\1 Fan Speed"
     value_threshold = 1.0
   }
 
   metric {
-    name_match = "gpu([\\d]+)_power_usage_report"
+    name_match = "([\\S]+)_power_usage_report"
     name = "\\1_power_usage"
     title= "\\1 Power Usage"
     value_threshold = 1.0
   }
 
   metric {
-    name_match = "gpu([\\d]+)_ecc_db_error"
+    name_match = "([\\S]+)_ecc_db_error"
     title= "\\1 Double Bit ECC Errors"
     value_threshold = 1.0
   }
   
   metric {
-    name_match = "gpu([\\d]+)_ecc_sb_error"
+    name_match = "([\\S]+)_ecc_sb_error"
     title= "\\1 Single Bit ECC Error Count"
     value_threshold = 1.0
   }
 
   metric {
-    name_match = "gpu([\\d]+)_power_violation_report"
+    name_match = "([\\S]+)_power_violation_report"
     title= "\\1 Power Violation Report"
     value_threshold = 1.0
   }
   
   metric {
-    name_match = "gpu([\\d]+)_encoder_util"
+    name_match = "([\\S]+)_encoder_util"
     title = "\\1 Encoder Utilization"
     value_threshold = 1.0 
   }
 
   metric {
-    name_match = "gpu([\\d]+)_decoder_util"
+    name_match = "([\\S]+)_decoder_util"
     title = "\\1 Decoder Utilization"
     value_threshold = 1.0
   }
   
   metric {
-    name_match = "gpu([\\d]+)_bar1_memory"
+    name_match = "([\\S]+)_bar1_memory"
     title = "\\1 Bar1 Memory"
   }
 
   metric {
-    name_match = "gpu([\\d]+)_bar1_max_memory"
+    name_match = "([\\S]+)_bar1_max_memory"
     title = "\\1 Bar1 Total Memory"
   } 
 }
@@ -118,7 +118,7 @@ collection_group {
   time_threshold = 1200
 
   metric {
-    name_match = "gpu([\\d]+)_ecc_mode"
+    name_match = "([\\S]+)_ecc_mode"
     name = "\\1_ecc_mode"
     title= "\\1 ECC Mode"
     value_threshold = 1.0
@@ -140,68 +140,68 @@ collection_group {
   }
 
   metric {
-    name_match = "gpu([\\d]+)_type"
+    name_match = "([\\S]+)_type"
     name = "\\1_type"
     title = "\\1 Type"
   }
 
   metric {
-    name_match = "gpu([\\d]+)_uuid"
+    name_match = "([\\S]+)_uuid"
     name = "\\1_uuid"
     title = "\\1 UUID"
   }
 
   metric {
-    name_match = "gpu([\\d]+)_pci_id"
+    name_match = "([\\S]+)_pci_id"
     name = "\\1_pci_id"
     title = "\\1 PCI ID"
   }
 
   metric {
-    name_match = "gpu([\\d]+)_mem_total"
+    name_match = "([\\S]+)_mem_total"
     name = "\\1_mem_total"
     title = "\\1 Memory Total"
   }
 
   metric {
-    name_match = "gpu([\\d]+)_max_graphics_clock"
+    name_match = "([\\S]+)_max_graphics_clock"
     name = "\\1_max_graphics_clock"
     title = "\\1 Max Graphics Clock"
     value_threshold = 1.0
   }
 
   metric {
-    name_match = "gpu([\\d]+)_max_sm_clock"
+    name_match = "([\\S]+)_max_sm_clock"
     name = "\\1_max_sm_clock"
     title = "\\1 Max SM Clock"
     value_threshold = 1.0
   }
 
   metric {
-    name_match = "gpu([\\d]+)_max_mem_clock"
+    name_match = "([\\S]+)_max_mem_clock"
     name = "\\1_max_mem_clock"
     title = "\\1 Max Memory Clock"
     value_threshold = 1.0
   }
 
   metric {
-    name_match = "gpu([\\d]+)_serial"
+    name_match = "([\\S]+)_serial"
     name = "\\1_serial"
     title = "\\1 Board Serial Number"
   }
   
   metric {
-    name_match = "gpu([\\d]+)_shutdown_temp"
+    name_match = "([\\S]+)_shutdown_temp"
     title = "\\1 Shutdown Temperature"
   }
 
   metric {
-    name_match = "gpu([\\d]+)_slowdown_temp"
+    name_match = "([\\S]+)_slowdown_temp"
     title = "\\1 Slowdown Temperature"
   }
   
    metric {
-    name_match = "gpu([\\d]+)_power_man_limit"
+    name_match = "([\\S]+)_power_man_limit"
     title= "\\1 Power Management Limit"
   } 
 }


### PR DESCRIPTION
The nvidia.pyconf file contained a regex matching any starting substring to a metric name. This is bad when multiple metrics have trailing string "_util" since there are multiple metrics that end in "_util" (i.e., *_encoder_util, *_decoder_util) commenting out specific ones and still remained collecting everything with a trailing "_util" as the metric. This also more closely matches the nvidia python module code.
