### PR TITLE
Switch to urllib2 to prevent exception

### DIFF
--- a/httpd/python_modules/httpd.py
+++ b/httpd/python_modules/httpd.py
@@ -35,7 +35,7 @@
 ###  http://www.gnu.org/licenses/gpl.txt
 
 import time
-import urllib
+import urllib2
 import subprocess
 import traceback
 
@@ -74,7 +74,7 @@ def update_stats():
 	try:
 		httpd_stats = {}
 		logging.debug(' opening URL: ' + str(STATUS_URL))
-		f = urllib.urlopen(STATUS_URL, None, 2)
+		f = urllib2.urlopen(STATUS_URL, None, 2)
 
 		for line in f.readlines():
 			diff = False


### PR DESCRIPTION
In 246721e429d3883a3f844e149748c35d7517be0a a change was made to add a timeout to various `urllib2` requests. However, in this module `urllib` is used rather than `urllib2`. Unfortunately, the third argument to `urllib.urlopen` is `proxies` (https://docs.python.org/2/library/urllib.html#urllib.urlopen) rather
than `timeout`, as in `urllib2` (https://docs.python.org/2/library/urllib2.html#urllib2.urlopen).

This was therefore causing the following exception:

```
Traceback (most recent call last):
  File "/usr/lib64/ganglia/python_modules/httpd.py", line 77, in update_stats
    f = urllib.urlopen(STATUS_URL, None, 2)
  File "/usr/lib64/python2.7/urllib.py", line 80, in urlopen
    opener = FancyURLopener(proxies=proxies)
  File "/usr/lib64/python2.7/urllib.py", line 614, in __init__
    URLopener.__init__(self, *args, **kwargs)
  File "/usr/lib64/python2.7/urllib.py", line 132, in __init__
    assert hasattr(proxies, 'has_key'), "proxies must be a mapping"
AssertionError: proxies must be a mapping
Exception AttributeError: "FancyURLopener instance has no attribute 'tempcache'" in <bound method FancyURLopener.__del__ of <urllib.FancyURLopener instance at 0x2133170>> ignored
```

A fix is to change this module to use `urllib2` so this works as expected.