### PR TITLE
Added lanplus option for IPMI v2.0

### DIFF
--- a/ipmi/python_modules/ipmi.py
+++ b/ipmi/python_modules/ipmi.py
@@ -115,6 +115,8 @@ def get_metrics():
         if ( 'use_sudo' in params.keys() and params['use_sudo'] ):
             command.append('sudo')
         command.append(params['ipmitool_bin'])
+        command.append('-I')
+        command.append('lanplus')
         if ( 'ipmi_ip' in params.keys() ):
             command.append("-H")
             command.append(params['ipmi_ip'])


### PR DESCRIPTION
IPMI v2.0 needs -I lanplus to connect using ipmi protocol