### PR TITLE
Updated Path to temps

### DIFF
--- a/system/hwmon/python_modules/hwmon.py
+++ b/system/hwmon/python_modules/hwmon.py
@@ -16,7 +16,7 @@ def metric_init(params):
     sensors = sorted(glob.glob(os.path.join(root, 'hwmon*')))
 
     for s in sensors:
-        temps = glob.glob(os.path.join(s, 'device/temp*_input'))
+        temps = glob.glob(os.path.join(s, 'temp*_input'))
         # dict values are default labels if no label files exist
         probes = dict(zip(temps, [os.path.basename(x) for x in temps]))
 


### PR DESCRIPTION
On recent distributions (Centos7 and Ubuntu 16) the path does not include the device directory.